### PR TITLE
Add a button to mute/unmute audio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /ui/node_modules
 /ui/flow-typed
 /ui/development_app_location.js
+/ui/.nyc_output
 /deploy
 __pycache__
 *.pyc

--- a/ui/src/components/wheel.jsx
+++ b/ui/src/components/wheel.jsx
@@ -300,7 +300,7 @@ export class Wheel extends PureComponent<WheelProps, WheelState> {
     this.setState({isMuted: newMuted});
     this.storage.setItem('isMuted', newMuted);
   
-    this.refs.clickSound.volume = !newMuted;
+    this.refs.clickSound.volume = (!newMuted ? 1 : 0);
   }
 
   render() {
@@ -347,8 +347,9 @@ export class Wheel extends PureComponent<WheelProps, WheelState> {
           }}
         >
           <Button
+            id='btnSoundToggle'
             onClick={this.toggleSound}
-           ref='btnSoundToggle'
+            ref='btnSoundToggle'
           >
             {isMuted ? '🔇' : '🔊'}
           </Button>

--- a/ui/src/components/wheel.jsx
+++ b/ui/src/components/wheel.jsx
@@ -24,7 +24,6 @@ import '../static_content/wheel_click.mp3';
 import 'isomorphic-fetch';
 import * as PIXI from 'pixi.js';
 
-
 interface WheelDispatchProps {
   dispatchWheelGet: PropTypes.func.isRequired,
   wheelFetch: PropTypes.object,
@@ -92,13 +91,17 @@ const MIN_FRAMES_BETWEEN_CLICKS = 5;
 export class Wheel extends PureComponent<WheelProps, WheelState> {
   constructor(props: WheelProps) {
     super(props);
+    
+    this.storage = global.window.localStorage;
+    
     this.state = {
       wheel: undefined,
       participants: undefined,
       isSpinning: false,
       fetching: true,
       rigExtra: undefined,
-    };
+      isMuted: (this.storage.getItem('isMuted') === 'true' ? true : false),
+    };  
     this.lastSector = 0;
   }
 
@@ -208,6 +211,7 @@ export class Wheel extends PureComponent<WheelProps, WheelState> {
     const currentSector = Math.floor(offset / this.state.sectorSize - 0.5);
     if (currentSector !== this.lastSector && time !== undefined) {
       if (this.lastClickTime === undefined || time - this.lastClickTime > MIN_FRAMES_BETWEEN_CLICKS) {
+        this.refs.clickSound.volume = !this.state.isMuted;
         this.refs.clickSound.currentTime = 0;
         this.refs.clickSound.play();
         this.lastClickTime = time;
@@ -289,11 +293,22 @@ export class Wheel extends PureComponent<WheelProps, WheelState> {
     window.open(this.state.selectedParticipant.url);
   }
 
+  toggleSound = () => {
+
+    var newMuted = !this.state.isMuted;
+
+    this.setState({isMuted: newMuted});
+    this.storage.setItem('isMuted', newMuted);
+  
+    this.refs.clickSound.volume = !newMuted;
+  }
+
   render() {
     const {wheelFetch, allParticipantsFetch, participantSuggestFetch} = this.props;
-    const {wheel, participants, isSpinning, selectedParticipant} = this.state;
+    const {wheel, participants, isSpinning, selectedParticipant, isMuted} = this.state;
 
     let participantName;
+
     if (selectedParticipant !== undefined && !isSpinning) {
       participantName = selectedParticipant.name;
     }
@@ -325,6 +340,19 @@ export class Wheel extends PureComponent<WheelProps, WheelState> {
                src={this.state.clickUrl}
                type='audio/mpeg' />
         {header}
+        <div style={{
+            float: 'left',
+            display: 'inline',
+            'padding-left': '1em',
+          }}
+        >
+          <Button
+            onClick={this.toggleSound}
+           ref='btnSoundToggle'
+          >
+            {isMuted ? '🔇' : '🔊'}
+          </Button>
+        </div>
         <div style={{textAlign: 'center', display: 'flex', justifyContent: 'space-around'}}>
           <LinkWrapper to={`wheel/${this.props.match.params.wheel_id}/participant`} style={{
             margin: '5px'
@@ -365,6 +393,7 @@ export class Wheel extends PureComponent<WheelProps, WheelState> {
               borderRadius: '50%',
             }} />
           <Button bsStyle='primary' disabled={isSpinning || participants === undefined || participants.length === 0}
+            id='btnSpin'
             style={{
             position: 'absolute',
             // Top position should always be wheel height * 0.5 - button height * 0.5

--- a/ui/test/components/wheel.test.jsx
+++ b/ui/test/components/wheel.test.jsx
@@ -27,6 +27,16 @@ describe('Wheel', function() {
   const wheelId = 'wheel_id_0';
   const participants = shimData.participants.filter((e) => e.wheel_id === shimData.wheels[0].id);
 
+  // Wheel uses localStorage which doesn't exist in tests. Mock it
+  // Open Question: do we want to test localStorage logic? If so, need to create a basic 
+  // implementation and add tests
+  if (!global.window.localStorage) {
+    global.window.localStorage = {
+      getItem() { return ''; },
+      setItem() {}
+    };
+  }
+
   console.log('participants: ', participants);
 
   const props = {
@@ -142,7 +152,7 @@ describe('Wheel', function() {
     // Let's strip out the drawing and animation stuff
     wrapper.instance().drawInitialWheel = sinon.spy();
     wrapper.instance().componentDidUpdate();
-    wrapper.find(Button).at(2).simulate('click');
+    wrapper.find('#btnSpin').first().simulate('click');
     expect(wrapper.instance().state.isSpinning).to.be.true;
     expect(wrapper.instance().state.selectedParticipant).to.be.undefined;
     expect(dispatchProps.dispatchParticipantSuggestGet.calledWith(wheelId)).to.be.true;

--- a/ui/test/components/wheel.test.jsx
+++ b/ui/test/components/wheel.test.jsx
@@ -297,4 +297,25 @@ describe('Wheel', function() {
     expect(dispatchProps.dispatchParticipantSelectPost.called).to.be.false;
     expect(window.open.called).to.be.false;
   });
+
+  it('Should mute audio when the mute button is pressed', () => {
+    const wrapper = shallowWithStore(<Wheel {...Object.assign({}, props, shallowProps, dispatchProps)} />);
+
+    // stub the audio control since refs don't work in the test
+    wrapper.instance().refs = {clickSound: {volume:1}};
+
+    const clickSound = wrapper.instance().refs.clickSound;
+    let btnSoundToggle = wrapper.find('#btnSoundToggle').first();
+    
+    btnSoundToggle.simulate('click');
+    expect(clickSound.volume).to.equal(0);
+  
+    btnSoundToggle.simulate('click');
+    expect(clickSound.volume).to.equal(1);
+  
+    btnSoundToggle.simulate('click');
+    expect(clickSound.volume).to.equal(0);
+  });
+  
 });
+


### PR DESCRIPTION
**Description of changes:**

* Button state is persisted locally from session to session
* Added basic localStorage mock for tests
* Wheel test: Spin button is now found by id, and not index to avoid having to update the index whenever the UI changes
* Added a test for the toggle button

**How Tested**
aws-ops-wheel/ui# npm run test

<snip>

```
66 passing (2s)

----------------------------------|----------|----------|----------|----------|----------------|
File                              |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------------------|----------|----------|----------|----------|----------------|
All files                         |    89.28 |    85.71 |    85.34 |    89.36 |                |
 src                              |    95.83 |    71.43 |      100 |    95.83 |                |
  index.jsx                       |      100 |      100 |      100 |      100 |                |
  types.jsx                       |      100 |      100 |      100 |      100 |                |
  util.jsx                        |       95 |    66.67 |      100 |       95 |             27 |
 src/components                   |    81.82 |    76.04 |    82.22 |    82.14 |                |
  app.jsx                         |    56.52 |    64.29 |    71.43 |    56.52 |... 5,81,82,100 |
  confirmation_modal.jsx          |      100 |      100 |      100 |      100 |                |
  login.jsx                       |      100 |      100 |      100 |      100 |                |
  navigation.jsx                  |      100 |      100 |      100 |      100 |                |
  notFound.jsx                    |      100 |      100 |      100 |      100 |                |
  wheel.jsx                       |    80.88 |    75.34 |    73.91 |    81.48 |... 254,441,448 |
 src/components/participant_table |    95.71 |    97.01 |    85.71 |    95.62 |                |
  participant_modal.jsx           |      100 |      100 |      100 |      100 |                |
  participant_row.jsx             |      100 |      100 |      100 |      100 |                |
  participant_table.jsx           |    93.41 |    96.08 |       75 |    93.33 |... 366,376,383 |
 src/components/wheel_table       |    95.52 |      100 |       88 |    95.45 |                |
  wheel_modal.jsx                 |      100 |      100 |      100 |      100 |                |
  wheel_row.jsx                   |      100 |      100 |      100 |      100 |                |
  wheel_table.jsx                 |    91.89 |      100 |    76.92 |    91.67 |    165,173,181 |
----------------------------------|----------|----------|----------|----------|----------------|

=============================== Coverage summary ===============================
Statements   : 89.28% ( 383/429 )
Branches     : 85.71% ( 174/203 )
Functions    : 85.34% ( 99/116 )
Lines        : 89.36% ( 378/423 )
================================================================================
```

**Contribution Agreement**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.