### PR TITLE
CloudFormation: S3 Source Bucket is World Readable (Public)

### DIFF
--- a/cloudformation/source-bucket.yml
+++ b/cloudformation/source-bucket.yml
@@ -19,4 +19,4 @@ Resources:
     Properties:
       VersioningConfiguration:
         Status: Enabled
-      AccessControl: AuthenticatedRead
+      AccessControl: BucketOwnerRead


### PR DESCRIPTION
**Description of changes**

S3 Bucket is set to 'AuthenticatedRead' which lets any authenticated AWS account read from the bucket (essentially readable by everyone). Changing this to 'BucketOwnerRead'.

**How Tested**

1. Re-ran CloudFormation (had to delete existing bucket first)
2. Verified permissions
3. Ran tests

**Open Source Confirmation**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.