### PR TITLE
Randomize the initial position of the wheel

### DIFF
--- a/ui/src/components/wheel.jsx
+++ b/ui/src/components/wheel.jsx
@@ -170,6 +170,7 @@ export class Wheel extends PureComponent<WheelProps, WheelState> {
     const {participants, sectorSize} = this.state;
     const fontSize = 16 + (80 / participants.length);
     const renderelement = ReactDOM.findDOMNode(this.refs.canvas);
+    
     this.application = new PIXI.Application({
        width: CANVAS_SIZE,
        height: CANVAS_SIZE,
@@ -177,14 +178,14 @@ export class Wheel extends PureComponent<WheelProps, WheelState> {
        antialias: true,
        backgroundColor: 0xFAFAFA,
     });
+
     this.spinTicker = this.application.ticker;
     this.wheelGraphic = new PIXI.Container();
     const graphics = new PIXI.Graphics();
     this.wheelGraphic.x = CANVAS_SIZE / 2;
     this.wheelGraphic.y = CANVAS_SIZE / 2;
     this.wheelGraphic.addChild(graphics);
-    // ctx.translate(this.refs.canvas.width / 2, this.refs.canvas.width / 2);
-    // ctx.font = `bold ${16 + 80 / participants.length}px Helvetica`;
+
     for (let i in participants) {
       i = parseInt(i);
       graphics.moveTo(0, 0);
@@ -192,13 +193,22 @@ export class Wheel extends PureComponent<WheelProps, WheelState> {
       graphics.arc(0, 0, OUTER_RADIUS, (i - 0.5) * sectorSize + Math.PI, (i + 0.5) * sectorSize + Math.PI);
       graphics.endFill();
       graphics.closePath();
+
       let textPositionAngle = sectorSize * i - Math.atan(-0.5 * fontSize / OUTER_RADIUS) + Math.PI;
       let basicText = new PIXI.Text(participants[i].name, {fontSize});
+
       basicText.x = TEXT_RADIUS * Math.cos(textPositionAngle);
       basicText.y = TEXT_RADIUS * Math.sin(textPositionAngle);
       basicText.rotation = sectorSize * i;
+
       this.wheelGraphic.addChild(basicText);
     }
+
+    // random start location so that specific projects don't always see their name at the starting point
+    // Note that this does not change the selection of the project (i.e. the project that the wheel
+    // points to at first load is still not selected)
+    this.wheelGraphic.rotation = (Math.random() * 360) * Math.PI / 180;
+
     this.application.stage.addChild(this.wheelGraphic);
   }
 


### PR DESCRIPTION
**Description of changes:**

With smaller wheels with clear names it becomes obvious that a specific project is always initially pointed at, even if they are not actually selected. This change introduces a random rotation into the wheel's initial draw so that this is no longer the case.

**How Tested**
```
  65 passing (1s)

----------------------------------|----------|----------|----------|----------|----------------|
File                              |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------------------|----------|----------|----------|----------|----------------|
All files                         |    89.39 |    85.79 |    85.22 |    89.47 |                |
 src                              |    95.83 |    71.43 |      100 |    95.83 |                |
  index.jsx                       |      100 |      100 |      100 |      100 |                |
  types.jsx                       |      100 |      100 |      100 |      100 |                |
  util.jsx                        |       95 |    66.67 |      100 |       95 |             27 |
 src/components                   |    81.87 |    75.56 |    81.82 |     82.2 |                |
  app.jsx                         |    56.52 |    64.29 |    71.43 |    56.52 |... 5,81,82,100 |
  confirmation_modal.jsx          |      100 |      100 |      100 |      100 |                |
  login.jsx                       |      100 |      100 |      100 |      100 |                |
  navigation.jsx                  |      100 |      100 |      100 |      100 |                |
  notFound.jsx                    |      100 |      100 |      100 |      100 |                |
  wheel.jsx                       |    80.92 |    74.63 |    72.73 |    81.54 |... 260,421,428 |
 src/components/participant_table |    95.71 |    97.01 |    85.71 |    95.62 |                |
  participant_modal.jsx           |      100 |      100 |      100 |      100 |                |
  participant_row.jsx             |      100 |      100 |      100 |      100 |                |
  participant_table.jsx           |    93.41 |    96.08 |       75 |    93.33 |... 366,376,383 |
 src/components/wheel_table       |    95.52 |      100 |       88 |    95.45 |                |
  wheel_modal.jsx                 |      100 |      100 |      100 |      100 |                |
  wheel_row.jsx                   |      100 |      100 |      100 |      100 |                |
  wheel_table.jsx                 |    91.89 |      100 |    76.92 |    91.67 |    165,173,181 |
----------------------------------|----------|----------|----------|----------|----------------|

=============================== Coverage summary ===============================
Statements   : 89.39% ( 379/424 )
Branches     : 85.79% ( 169/197 )
Functions    : 85.22% ( 98/115 )
Lines        : 89.47% ( 374/418 )
================================================================================
```

**Open Source Confirmation**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.