### PR TITLE
Fix DynamoDB mocking for some unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,11 @@
 /ui/development_app_location.js
 /ui/.nyc_output
 /deploy
+.env
+.venv
+env/
+venv/
 __pycache__
 *.pyc
+.coverage
+.pytest_cache/

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -14,6 +14,7 @@
 import json
 import os
 import pytest
+import utils
 from utils import add_extended_table_functions
 from boto3.session import Session
 from moto import mock_dynamodb2
@@ -91,6 +92,7 @@ def mock_dynamodb():
 def mock_wheel_table(mock_dynamodb):
     Wheel = mock_dynamodb.Table(WHEEL_TABLE_NAME)
     add_extended_table_functions(Wheel)
+    utils.Wheel = Wheel
     yield Wheel
     wheels = Wheel.scan({})['Items']
     with Wheel.batch_writer() as batch:
@@ -102,6 +104,7 @@ def mock_wheel_table(mock_dynamodb):
 def mock_participant_table(mock_dynamodb):
     WheelParticipant = mock_dynamodb.Table(PARTICIPANT_TABLE_NAME)
     add_extended_table_functions(WheelParticipant)
+    utils.WheelParticipant = WheelParticipant
     yield WheelParticipant
     participants = WheelParticipant.scan({})['Items']
     with WheelParticipant.batch_writer() as batch:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+awscli
+boto3
+pyaml
+pytest
+pytest-cov
+moto


### PR DESCRIPTION
Unless something is very wrong with my environment, some of the unit tests cause real calls to DynamoDB using my local credentials file, instead of mocked calls with mock credentials.  I haven't yet stood up a stack or any of the real tables in my account, so I get a bunch of ResourceNotFound errors when running the unit tests.

The cause is that the "Wheel" and "WheelParticipant" global variables are created using a real DynamoDB client, and then used in the classes being tested:
https://github.com/aws/aws-ops-wheel/blob/master/api/utils.py#L21-L23
https://github.com/aws/aws-ops-wheel/blob/master/api/choice_algorithm.py#L73

I fixed this by replacing the global variables with the mocked versions as part of the test setup.

Testing:
```
python3.6 -m virtualenv env
source env/bin/activate
pip install -r requirements.txt

AWS_ACCESS_KEY_ID=fake AWS_SECRET_ACCESS_KEY=fake AWS_DEFAULT_REGION=us-west-2 pytest --verbose  --cov-report term-missing --cov ./ -s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.