### PR TITLE
Force new API Gateway deployment for every CFN stack update

### DIFF
--- a/_compile_cloudformation_template.py
+++ b/_compile_cloudformation_template.py
@@ -22,6 +22,7 @@ import os
 import wheel
 import wheel_participant
 
+import time
 
 class Ref(str): pass
 class GetAtt(str): pass
@@ -116,14 +117,20 @@ class TemplateCompiler:
                         config.setdefault('Parameters', {})
                         config['Parameters'][ref] = {'Type': 'String'}
 
-                for resource in config['Resources'].keys():
-                    config['Outputs'][resource] = {'Value': Ref(resource)}
+                for resource in list(config['Resources'].keys()):
+                    if config['Resources'][resource]['Type'] == 'AWS::ApiGateway::Deployment':
+                        # Unique-ify the logical ID to force a new deployment for each stack update
+                        unique_resource_name = f"{resource}{str(int(time.time()))}"
+                        config['Resources'][unique_resource_name] = config['Resources'].pop(resource)
+                        config['Outputs'][resource] = {'Value': Ref(unique_resource_name)}
+                    else:
+                        config['Outputs'][resource] = {'Value': Ref(resource)}
 
                 for output in config['Outputs']:
                     global_resources[output] = stack_name
 
                 with open(os.path.join(self.out_dir, template_filename), 'w') as f:
-                    f.write(yaml.dump(config))
+                    f.write(yaml.dump(config, default_flow_style=False))
 
             # Compile the overall configuration
             overall_config = yaml.load(open(os.path.join(self.in_dir, 'aws-ops-wheel.yml')))

--- a/cloudformation/api_gateway.yml
+++ b/cloudformation/api_gateway.yml
@@ -23,7 +23,7 @@ Resources:
   AWSOpsWheelAPIApp:
     Type: AWS::ApiGateway::Deployment
     Properties:
-      Description: Initial deployment of the AWS Ops Wheel API
+      Description: Deployment of the AWS Ops Wheel API
       RestApiId: {Ref: AWSOpsWheelAPI}
       StageName: app
   AWSOpsWheelS3Role:

--- a/run
+++ b/run
@@ -205,11 +205,6 @@ class DevManager:
         api_resources = list_stack_resources(self.stack_name, 'ApiGatewayStack')
         api_id = api_resources['AWSOpsWheelAPI']['PhysicalResourceId']
 
-        if action == 'update':
-            LOG.info(f'Deploying updated APIGateway to app endpoint')
-            # Deploy to the app stack
-            aws('apigateway', 'create-deployment', '--rest-api-id', api_id, '--stage-name', 'app')
-
         with open(os.path.join(UI_DIRECTORY, 'development_app_location.js'), 'w') as f:
             f.write(f"module.exports = 'https://{api_id}.execute-api.{self.region}.amazonaws.com';")
 


### PR DESCRIPTION
Use a timestamp in the stage description for AWS::ApiGateway::Deployment resources to create a unique deployment resource in every stack update

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.