### PR TITLE
Forcing refresh session before api call

### DIFF
--- a/ui/src/components/app.jsx
+++ b/ui/src/components/app.jsx
@@ -82,6 +82,14 @@ class App extends Component<AppProps, AppState> {
     this.setState({cognitoUserPool: undefined, cognitoSession: undefined});
   }
 
+  handleClickCapture = () => {
+    if(this.state.cognitoUserPool!== undefined){
+      this.refreshSession()
+    }else{
+      this.componentDidUpdate()
+    }
+  }
+
   render() {
     if (!this.props.configFetch.fulfilled) {
       return (<div>Loading ...</div>);
@@ -99,7 +107,7 @@ class App extends Component<AppProps, AppState> {
     if (this.state.cognitoSession !== undefined && this.state.cognitoSession.isValid()) {
       return (
           <BrowserRouter>
-            <div>
+            <div id="grandparent" onClickCapture={this.handleClickCapture}>
               <Navigation {...childProps} />
               <Switch>
                 <Route path='/app' exact={true} component={WheelTable} />


### PR DESCRIPTION
*Issue #, if available:*
If ops-wheel has been sitting idle for more than an hour and user perform an operation then the operation fails and user taken back to the login page.

Root cause: Cognito session has not been refreshed for more than an hour and Authorization header expired.
*Description of changes:*
On every button click, the change will refresh the session.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.