### PR TITLE
Fixes unit tests by using default region instead of us-west-2

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -28,9 +28,7 @@ def mock_dynamodb():
 
     mock_dynamodb2().start()
 
-    session = Session(aws_access_key_id='<ACCESS_KEY_ID>',
-                      aws_secret_access_key='<SECRET_KEY>',
-                      region_name='us-west-2')
+    session = Session(aws_access_key_id='<ACCESS_KEY_ID>', aws_secret_access_key='<SECRET_KEY>')
     dynamodb = session.resource('dynamodb')
 
     wheel_table = dynamodb.create_table(


### PR DESCRIPTION
**Issue #, if available:**

n/a

**Description of changes:**

Python unit tests were broken. `conftest.py` set a specific region, but elsewhere it used a default, so the code under test wasn't finding the mock dynamodb client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.