### PR TITLE
Two bug fixes for S3 urls and buckets in us-east-1

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -28,9 +28,7 @@ def mock_dynamodb():
 
     mock_dynamodb2().start()
 
-    session = Session(aws_access_key_id='<ACCESS_KEY_ID>',
-                      aws_secret_access_key='<SECRET_KEY>',
-                      region_name='us-west-2')
+    session = Session(aws_access_key_id='<ACCESS_KEY_ID>', aws_secret_access_key='<SECRET_KEY>')
     dynamodb = session.resource('dynamodb')
 
     wheel_table = dynamodb.create_table(

--- a/run
+++ b/run
@@ -110,11 +110,14 @@ class DevManager:
             self._region = aws(
                 's3api', 'get-bucket-location', '--bucket', self.s3_bucket
             )['LocationConstraint']
+        # LocationConstraint is null if bucket is in us-east-1
+        if self._region is None:
+            self._region = 'us-east-1'
         return self._region
 
     @property
     def s3_bucket_public_url(self):
-        return f'https://s3-{self.region}.amazonaws.com/{self.s3_bucket}'
+        return f'https://s3.{self.region}.amazonaws.com/{self.s3_bucket}'
 
     def build(self):
         if self.clean and os.path.exists(BUILD_DIRECTORY):


### PR DESCRIPTION
**Issue #, if available:**

n/a

**Description of changes:**

1. Fixes bug that caused buckets in us-east-1 to look have the region of None
2. Fixes bug in creation of S3 url used for API Gateway proxy (I don't know how this ever worked)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.