### PR TITLE
Changes DynamoDB tables to on-demand

### DIFF
--- a/cloudformation/lambda.yml
+++ b/cloudformation/lambda.yml
@@ -57,7 +57,7 @@ Resources:
       KeySchema:
       - {AttributeName: wheel_id, KeyType: HASH}
       - {AttributeName: id, KeyType: RANGE}
-      ProvisionedThroughput: {ReadCapacityUnits: '5', WriteCapacityUnits: '5'}
+      BillingMode: PAY_PER_REQUEST
     Type: AWS::DynamoDB::Table
   wheelDynamoDBTable:
     Properties:
@@ -65,5 +65,5 @@ Resources:
       - {AttributeName: id, AttributeType: S}
       KeySchema:
       - {AttributeName: id, KeyType: HASH}
-      ProvisionedThroughput: {ReadCapacityUnits: '1', WriteCapacityUnits: '1'}
+      BillingMode: PAY_PER_REQUEST
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/aws/aws-ops-wheel/issues/27

**Description of changes:**

Use DynamoDB on-demand tables instead of provisioned. Owned to the way people use something like this (very infrequent activity) it should be cheaper.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.