### PR TITLE
Added text wrap for participant names

### DIFF
--- a/ui/src/components/wheel.jsx
+++ b/ui/src/components/wheel.jsx
@@ -220,6 +220,9 @@ export class Wheel extends PureComponent<WheelProps, WheelState> {
         participantName = participantName.substring(0, (maxParticipantNameLength - 3)) + '...';
       }
       let basicText = new PIXI.Text(participantName, {fontSize});
+      basicText.style.wordWrap = true;
+      basicText.style.wordWrapWidth = TEXT_RADIUS * 0.8;
+      basicText.style.align = 'center';
 
       basicText.x = TEXT_RADIUS * Math.cos(textPositionAngle);
       basicText.y = TEXT_RADIUS * Math.sin(textPositionAngle);


### PR DESCRIPTION
*Github Issue #9 

*Description of changes:*
Even with truncation, participants names with more than 10 characters on a wheel with less than 5 participants does not render nicely, due to the scaled up font size. 
Wrapping the participant name text solves this problem

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
