### PR TITLE
Verbiage to choose participant

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The endpoint will then be in the CloudFormation Stack Output messages.
 - Delete a wheel
 - Spin the wheel and suggest a participant
   - ***Notes:*** This does not adjust weighting, so if you're unhappy with the result, you can spin again.
-- Proceed: Accept the suggested participant
+- Choose: Accept the suggested participant
 - Reset: Restart all participants to equal weights as 1.0
 
 ### Participant Operations


### PR DESCRIPTION
Update verbiage in the Wheel Operations section of ReadMe to swap the verb "Proceed" to "Choose", which mirrors the button in the UX. It's a minor detail, but it would surprise you how many times I've trained this specific point to teams.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
