### PR TITLE
fix(auth): Add RS256 signature verification to JWT token validation

### DIFF
--- a/api-v2/api_gateway_authorizer.py
+++ b/api-v2/api_gateway_authorizer.py
@@ -12,66 +12,15 @@ sys.path.insert(0, '/opt/python/api-v2')
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-def decode_jwt_payload_only(token: str) -> dict:
-    """
-    Decode JWT payload without signature verification (inline copy)
-    """
-    import base64
-    try:
-        parts = token.split('.')
-        if len(parts) != 3:
-            raise ValueError("Invalid JWT format")
-        
-        # Decode payload (middle part)
-        payload_encoded = parts[1]
-        # Add padding if necessary
-        payload_encoded += '=' * (4 - len(payload_encoded) % 4)
-        payload_bytes = base64.urlsafe_b64decode(payload_encoded)
-        payload = json.loads(payload_bytes.decode('utf-8'))
-        
-        return payload
-    except Exception as e:
-        raise ValueError(f"Failed to decode JWT payload: {str(e)}")
+from jwt_verifier import verify_cognito_token
 
-def validate_token_basic(token: str, user_pool_id: str, client_id: str) -> dict:
+def validate_token(token: str, user_pool_id: str, client_id: str) -> dict:
     """
-    Basic JWT token validation without signature verification (inline copy)
+    Validate a Cognito JWT token with full cryptographic signature verification.
+    Uses the shared jwt_verifier module which fetches JWKS from the Cognito
+    User Pool and verifies the RS256 signature before trusting any claims.
     """
-    import time
-    try:
-        payload = decode_jwt_payload_only(token)
-        
-        # Basic validations
-        required_claims = ['sub', 'exp', 'iss', 'aud']
-        for claim in required_claims:
-            if claim not in payload:
-                raise ValueError(f"Missing required claim: {claim}")
-        
-        # Check issuer format (handle AWS Cognito service issue with typo)
-        region = user_pool_id.split('_')[0]
-        expected_iss = f"https://cognito-idp.{region}.amazonaws.com/{user_pool_id}"
-        typo_iss = f"https://cognitm-idp.{region}.amazonaws.com/{user_pool_id}"  # AWS service issue
-        
-        if payload['iss'] not in [expected_iss, typo_iss]:
-            raise ValueError(f"Invalid issuer: {payload['iss']}. Expected: {expected_iss}")
-        
-        # Check audience
-        if payload['aud'] != client_id:
-            raise ValueError(f"Invalid audience: {payload['aud']}")
-        
-        # Check token type
-        if payload.get('token_use') != 'id':
-            raise ValueError(f"Invalid token use: {payload.get('token_use')}")
-        
-        # Check expiration (basic check)
-        current_time = int(time.time())
-        if payload['exp'] < current_time:
-            raise ValueError("Token has expired")
-        
-        return payload
-        
-    except Exception as e:
-        raise ValueError(f"Token validation failed: {str(e)}")
+    return verify_cognito_token(token, user_pool_id, client_id)
 
 def lookup_user_wheel_group_info(user_email: str) -> dict:
     """
@@ -160,8 +109,8 @@ def lambda_handler(event, context):
                 logger.error("Missing Cognito configuration in environment variables")
                 raise Exception('Unauthorized')
             
-            # Basic JWT validation
-            payload = validate_token_basic(jwt_token, user_pool_id, client_id)
+            # Verify JWT with cryptographic signature validation
+            payload = validate_token(jwt_token, user_pool_id, client_id)
             
             # Get user email from JWT
             user_email = payload.get('email')

--- a/api-v2/jwt_verifier.py
+++ b/api-v2/jwt_verifier.py
@@ -1,0 +1,158 @@
+"""
+Shared JWT verification module for AWS Ops Wheel v2.
+
+Fetches JWKS from the Cognito User Pool, caches public keys, and verifies
+RS256 signatures using PyJWT. This replaces the insecure base64-only decoding
+that was previously used in api_gateway_authorizer.py and wheel_group_middleware.py.
+"""
+
+import json
+import logging
+import time
+import urllib.request
+from typing import Any, Dict, Optional
+
+import jwt
+from jwt.algorithms import RSAAlgorithm
+
+logger = logging.getLogger(__name__)
+
+# Module-level cache for JWKS keys
+_jwks_cache: Dict[str, Any] = {}
+_jwks_cache_timestamp: float = 0
+_JWKS_CACHE_TTL_SECONDS = 3600  # 1 hour
+
+
+def _get_jwks_url(user_pool_id: str) -> str:
+    """Build the JWKS URL for a Cognito User Pool."""
+    region = user_pool_id.split('_')[0]
+    return f"https://cognito-idp.{region}.amazonaws.com/{user_pool_id}/.well-known/jwks.json"
+
+
+def _get_issuer(user_pool_id: str) -> str:
+    """Build the expected issuer URL for a Cognito User Pool."""
+    region = user_pool_id.split('_')[0]
+    return f"https://cognito-idp.{region}.amazonaws.com/{user_pool_id}"
+
+
+def _fetch_jwks(user_pool_id: str) -> Dict[str, Any]:
+    """
+    Fetch and cache JWKS (JSON Web Key Set) from the Cognito User Pool.
+
+    Keys are cached for _JWKS_CACHE_TTL_SECONDS to avoid hitting the
+    JWKS endpoint on every request.
+    """
+    global _jwks_cache, _jwks_cache_timestamp
+
+    now = time.time()
+    if _jwks_cache and (now - _jwks_cache_timestamp) < _JWKS_CACHE_TTL_SECONDS:
+        return _jwks_cache
+
+    jwks_url = _get_jwks_url(user_pool_id)
+    logger.info(f"Fetching JWKS from {jwks_url}")
+
+    try:
+        req = urllib.request.Request(jwks_url)
+        with urllib.request.urlopen(req, timeout=5) as response:
+            jwks = json.loads(response.read().decode('utf-8'))
+    except Exception as e:
+        logger.error(f"Failed to fetch JWKS from {jwks_url}: {e}")
+        # If we have a stale cache, use it rather than failing open
+        if _jwks_cache:
+            logger.warning("Using stale JWKS cache after fetch failure")
+            return _jwks_cache
+        raise ValueError(f"Unable to fetch JWKS and no cached keys available: {e}")
+
+    _jwks_cache = jwks
+    _jwks_cache_timestamp = now
+    return jwks
+
+
+def _get_signing_key(token: str, user_pool_id: str):
+    """
+    Extract the signing key from JWKS that matches the token's kid (Key ID).
+    """
+    try:
+        unverified_header = jwt.get_unverified_header(token)
+    except jwt.exceptions.DecodeError as e:
+        raise ValueError(f"Invalid JWT header: {e}")
+
+    kid = unverified_header.get('kid')
+    if not kid:
+        raise ValueError("JWT header missing 'kid' (Key ID)")
+
+    jwks = _fetch_jwks(user_pool_id)
+    keys = jwks.get('keys', [])
+
+    for key_data in keys:
+        if key_data.get('kid') == kid:
+            return RSAAlgorithm.from_jwk(json.dumps(key_data))
+
+    # Key not found — maybe keys rotated. Force refresh and retry once.
+    global _jwks_cache_timestamp
+    _jwks_cache_timestamp = 0
+    jwks = _fetch_jwks(user_pool_id)
+    keys = jwks.get('keys', [])
+
+    for key_data in keys:
+        if key_data.get('kid') == kid:
+            return RSAAlgorithm.from_jwk(json.dumps(key_data))
+
+    raise ValueError(f"Unable to find signing key for kid: {kid}")
+
+
+def verify_cognito_token(
+    token: str,
+    user_pool_id: str,
+    client_id: str,
+    token_use: str = "id",
+) -> Dict[str, Any]:
+    """
+    Verify a Cognito JWT token with full RS256 signature verification.
+
+    Args:
+        token: The raw JWT string.
+        user_pool_id: The Cognito User Pool ID (e.g. us-west-2_AbCdEfG).
+        client_id: The Cognito App Client ID.
+        token_use: Expected token_use claim (default: "id").
+
+    Returns:
+        The verified and decoded JWT payload as a dict.
+
+    Raises:
+        ValueError: If the token is invalid, expired, or signature verification fails.
+    """
+    signing_key = _get_signing_key(token, user_pool_id)
+    expected_issuer = _get_issuer(user_pool_id)
+
+    try:
+        payload = jwt.decode(
+            token,
+            signing_key,
+            algorithms=["RS256"],
+            issuer=expected_issuer,
+            audience=client_id,
+            options={
+                "require": ["sub", "exp", "iss", "aud", "token_use"],
+            },
+        )
+    except jwt.ExpiredSignatureError:
+        raise ValueError("Token has expired")
+    except jwt.InvalidIssuerError:
+        raise ValueError("Invalid token issuer")
+    except jwt.InvalidAudienceError:
+        raise ValueError("Invalid token audience")
+    except jwt.InvalidSignatureError:
+        raise ValueError("Invalid token signature")
+    except jwt.DecodeError as e:
+        raise ValueError(f"Token decode failed: {e}")
+    except Exception as e:
+        raise ValueError(f"Token verification failed: {e}")
+
+    # Verify token_use claim
+    if payload.get('token_use') != token_use:
+        raise ValueError(
+            f"Invalid token_use: expected '{token_use}', got '{payload.get('token_use')}'"
+        )
+
+    return payload

--- a/api-v2/tests/test_api_gateway_authorizer.py
+++ b/api-v2/tests/test_api_gateway_authorizer.py
@@ -20,7 +20,7 @@ from base import BadRequestError, NotFoundError
 
 # Import authorizer functions
 from api_gateway_authorizer import (
-    lambda_handler, decode_jwt_payload_only, validate_token_basic,
+    lambda_handler, validate_token,
     lookup_user_wheel_group_info, get_role_permissions, generate_policy
 )
 
@@ -52,17 +52,11 @@ def create_valid_jwt_payload(user_email="test@example.com", **overrides):
 
 
 def create_jwt_token(payload):
-    """Create a mock JWT token with the given payload"""
-    # Create header (not validated in this implementation)
+    """Create a mock JWT token with the given payload (for use with mocked verification)"""
     header = {'alg': 'RS256', 'typ': 'JWT'}
     header_encoded = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip('=')
-    
-    # Encode payload
     payload_encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
-    
-    # Create signature (not validated in this implementation)
     signature = base64.urlsafe_b64encode(b'fake-signature').decode().rstrip('=')
-    
     return f"{header_encoded}.{payload_encoded}.{signature}"
 
 
@@ -79,13 +73,13 @@ def create_authorizer_event(token=None, method_arn="arn:aws:execute-api:us-west-
 def validate_iam_policy_structure(policy):
     """Validate that IAM policy has correct structure"""
     assert 'principalId' in policy, "Policy must have principalId"
-    
+
     if 'policyDocument' in policy:
         policy_doc = policy['policyDocument']
         assert policy_doc['Version'] == '2012-10-17', "Policy must have correct version"
         assert 'Statement' in policy_doc, "Policy must have Statement"
         assert isinstance(policy_doc['Statement'], list), "Statement must be a list"
-        
+
         for statement in policy_doc['Statement']:
             assert 'Action' in statement, "Statement must have Action"
             assert 'Effect' in statement, "Statement must have Effect"
@@ -109,104 +103,63 @@ def validate_regular_user_context(context, expected_wheel_group_id, expected_rol
     assert context['user_id'] != ''
 
 
-# JWT Validation Tests (8 tests)
+# JWT Verification Tests (6 tests)
 
-def test_decode_jwt_payload_only_valid_token():
-    """Test JWT payload decoding with valid token"""
-    payload = create_valid_jwt_payload()
-    token = create_jwt_token(payload)
-    
-    decoded = decode_jwt_payload_only(token)
-    
-    assert decoded['sub'] == payload['sub']
-    assert decoded['email'] == payload['email'] 
-    assert decoded['exp'] == payload['exp']
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_validate_token_delegates_to_jwt_verifier(mock_verify):
+    """Test that validate_token delegates to jwt_verifier.verify_cognito_token"""
+    expected_payload = create_valid_jwt_payload()
+    mock_verify.return_value = expected_payload
 
+    result = validate_token('fake.token.here', 'us-west-2_TestPool', 'test-client-id')
 
-def test_decode_jwt_payload_only_invalid_format():
-    """Test JWT decoding fails with malformed token"""
-    invalid_tokens = [
-        "invalid.token",  # Only 2 parts
-        "invalid.token.signature.extra",  # Too many parts
-        "not-base64.not-base64.not-base64",  # Invalid base64
-        "",  # Empty string
-        "invalid"  # Single part
-    ]
-    
-    for invalid_token in invalid_tokens:
-        with pytest.raises(ValueError, match="Failed to decode JWT payload"):
-            decode_jwt_payload_only(invalid_token)
+    mock_verify.assert_called_once_with('fake.token.here', 'us-west-2_TestPool', 'test-client-id')
+    assert result == expected_payload
 
 
-@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_validate_token_basic_valid_token():
-    """Test basic token validation with valid token"""
-    payload = create_valid_jwt_payload()
-    token = create_jwt_token(payload)
-    
-    result = validate_token_basic(token, 'us-west-2_TestPool', 'test-client-id')
-    
-    assert result['sub'] == payload['sub']
-    assert result['email'] == payload['email']
-    assert result['exp'] == payload['exp']
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_validate_token_propagates_expired_error(mock_verify):
+    """Test that validate_token propagates expiration errors from jwt_verifier"""
+    mock_verify.side_effect = ValueError("Token has expired")
 
-
-@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_validate_token_basic_expired_token():
-    """Test token validation fails with expired token"""
-    expired_time = int(time.time()) - 3600  # Expired 1 hour ago
-    payload = create_valid_jwt_payload(exp=expired_time)
-    token = create_jwt_token(payload)
-    
     with pytest.raises(ValueError, match="Token has expired"):
-        validate_token_basic(token, 'us-west-2_TestPool', 'test-client-id')
+        validate_token('expired.token.here', 'us-west-2_TestPool', 'test-client-id')
 
 
-@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_validate_token_basic_missing_required_claims():
-    """Test token validation fails with missing required claims"""
-    base_payload = create_valid_jwt_payload()
-    required_claims = ['sub', 'exp', 'iss', 'aud']
-    
-    for claim in required_claims:
-        payload = base_payload.copy()
-        del payload[claim]
-        token = create_jwt_token(payload)
-        
-        with pytest.raises(ValueError, match=f"Missing required claim: {claim}"):
-            validate_token_basic(token, 'us-west-2_TestPool', 'test-client-id')
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_validate_token_propagates_signature_error(mock_verify):
+    """Test that validate_token rejects tokens with invalid signatures"""
+    mock_verify.side_effect = ValueError("Invalid token signature")
+
+    with pytest.raises(ValueError, match="Invalid token signature"):
+        validate_token('forged.token.here', 'us-west-2_TestPool', 'test-client-id')
 
 
-@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_validate_token_basic_invalid_issuer():
-    """Test token validation fails with invalid issuer"""
-    payload = create_valid_jwt_payload(iss='https://malicious-site.com')
-    token = create_jwt_token(payload)
-    
-    with pytest.raises(ValueError, match="Invalid issuer"):
-        validate_token_basic(token, 'us-west-2_TestPool', 'test-client-id')
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_validate_token_propagates_issuer_error(mock_verify):
+    """Test that validate_token rejects tokens with invalid issuer"""
+    mock_verify.side_effect = ValueError("Invalid token issuer")
+
+    with pytest.raises(ValueError, match="Invalid token issuer"):
+        validate_token('bad-issuer.token.here', 'us-west-2_TestPool', 'test-client-id')
 
 
-@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_validate_token_basic_invalid_audience():
-    """Test token validation fails with invalid audience"""
-    payload = create_valid_jwt_payload(aud='wrong-client-id')
-    token = create_jwt_token(payload)
-    
-    with pytest.raises(ValueError, match="Invalid audience"):
-        validate_token_basic(token, 'us-west-2_TestPool', 'test-client-id')
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_validate_token_propagates_audience_error(mock_verify):
+    """Test that validate_token rejects tokens with invalid audience"""
+    mock_verify.side_effect = ValueError("Invalid token audience")
+
+    with pytest.raises(ValueError, match="Invalid token audience"):
+        validate_token('bad-audience.token.here', 'us-west-2_TestPool', 'test-client-id')
 
 
-@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_validate_token_basic_cognito_typo_issuer_handling():
-    """Test token validation handles AWS Cognito service typo in issuer"""
-    # Test the known AWS service issue with 'cognitm-idp' typo
-    payload = create_valid_jwt_payload(iss='https://cognitm-idp.us-west-2.amazonaws.com/us-west-2_TestPool')
-    token = create_jwt_token(payload)
-    
-    # Should not raise exception due to typo handling
-    result = validate_token_basic(token, 'us-west-2_TestPool', 'test-client-id')
-    assert result['sub'] == payload['sub']
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_validate_token_rejects_malformed_token(mock_verify):
+    """Test that validate_token rejects malformed tokens"""
+    mock_verify.side_effect = ValueError("Token decode failed: Not enough segments")
+
+    with pytest.raises(ValueError, match="Token decode failed"):
+        validate_token('not-a-jwt', 'us-west-2_TestPool', 'test-client-id')
 
 
 # Database Integration Tests (6 tests)
@@ -214,18 +167,16 @@ def test_validate_token_basic_cognito_typo_issuer_handling():
 @patch('boto3.resource')
 def test_lookup_user_wheel_group_info_success(mock_boto3_resource):
     """Test successful user wheel group lookup"""
-    # Mock DynamoDB resource and tables
     mock_dynamodb_resource = Mock()
     mock_users_table = Mock()
     mock_wheel_groups_table = Mock()
-    
+
     mock_boto3_resource.return_value = mock_dynamodb_resource
     mock_dynamodb_resource.Table.side_effect = lambda name: {
         'OpsWheelV2-Users-test': mock_users_table,
         'OpsWheelV2-WheelGroups-test': mock_wheel_groups_table
     }[name]
-    
-    # Mock database scan response - must return actual list for items[0] access
+
     mock_users_table.scan.return_value = {
         'Items': [{
             'user_id': 'test-user-123',
@@ -235,17 +186,16 @@ def test_lookup_user_wheel_group_info_success(mock_boto3_resource):
             'email': 'test@example.com'
         }]
     }
-    
-    # Mock wheel group response
+
     mock_wheel_groups_table.get_item.return_value = {
         'Item': {
             'wheel_group_id': 'wg-123',
             'wheel_group_name': 'Test Wheel Group'
         }
     }
-    
+
     result = lookup_user_wheel_group_info('test@example.com')
-    
+
     assert result['user_id'] == 'test-user-123'
     assert result['wheel_group_id'] == 'wg-123'
     assert result['wheel_group_name'] == 'Test Wheel Group'
@@ -258,13 +208,12 @@ def test_lookup_user_wheel_group_info_user_not_found(mock_boto3_resource):
     """Test user lookup when user doesn't exist"""
     mock_dynamodb_resource = Mock()
     mock_users_table = Mock()
-    
+
     mock_boto3_resource.return_value = mock_dynamodb_resource
     mock_dynamodb_resource.Table.return_value = mock_users_table
-    
-    # Mock empty scan response 
+
     mock_users_table.scan.return_value = {'Items': []}
-    
+
     with pytest.raises(ValueError, match="User not found in database: nonexistent@example.com"):
         lookup_user_wheel_group_info('nonexistent@example.com')
 
@@ -275,14 +224,13 @@ def test_lookup_user_wheel_group_info_wheel_group_not_found(mock_boto3_resource)
     mock_dynamodb_resource = Mock()
     mock_users_table = Mock()
     mock_wheel_groups_table = Mock()
-    
+
     mock_boto3_resource.return_value = mock_dynamodb_resource
     mock_dynamodb_resource.Table.side_effect = lambda name: {
         'OpsWheelV2-Users-test': mock_users_table,
         'OpsWheelV2-WheelGroups-test': mock_wheel_groups_table
     }[name]
-    
-    # Mock user exists but wheel group doesn't - items must be a list
+
     items_list = [{
         'user_id': 'test-user-123',
         'wheel_group_id': 'nonexistent-wg',
@@ -290,12 +238,11 @@ def test_lookup_user_wheel_group_info_wheel_group_not_found(mock_boto3_resource)
         'email': 'test@example.com'
     }]
     mock_users_table.scan.return_value = {'Items': items_list}
-    
+
     mock_wheel_groups_table.get_item.return_value = {}  # No Item key
-    
+
     result = lookup_user_wheel_group_info('test@example.com')
-    
-    # Should still work, just use wheel_group_id as name
+
     assert result['wheel_group_name'] == 'nonexistent-wg'
 
 
@@ -304,41 +251,36 @@ def test_lookup_user_wheel_group_info_database_error(mock_boto3_resource):
     """Test user lookup handles database errors gracefully"""
     mock_dynamodb_resource = Mock()
     mock_users_table = Mock()
-    
+
     mock_boto3_resource.return_value = mock_dynamodb_resource
     mock_dynamodb_resource.Table.return_value = mock_users_table
-    
-    # Mock database error - use scan method since that's what the implementation uses
+
     mock_users_table.scan.side_effect = Exception("DynamoDB connection failed")
-    
+
     with pytest.raises(ValueError, match="Failed to lookup user wheel group info"):
         lookup_user_wheel_group_info('test@example.com')
 
 
 def test_get_role_permissions_all_roles():
     """Test role permissions mapping for all role types"""
-    # Test ADMIN permissions
     admin_perms = get_role_permissions('ADMIN')
     expected_admin = [
-        'create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel', 
+        'create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel',
         'view_wheels', 'manage_users', 'manage_wheel_group', 'rig_wheel'
     ]
     assert set(admin_perms) == set(expected_admin)
-    
-    # Test WHEEL_ADMIN permissions
+
     wheel_admin_perms = get_role_permissions('WHEEL_ADMIN')
     expected_wheel_admin = [
-        'create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel', 
+        'create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel',
         'view_wheels', 'rig_wheel'
     ]
     assert set(wheel_admin_perms) == set(expected_wheel_admin)
-    
-    # Test USER permissions
+
     user_perms = get_role_permissions('USER')
     expected_user = ['spin_wheel', 'view_wheels']
     assert set(user_perms) == set(expected_user)
-    
-    # Test unknown role defaults to USER
+
     unknown_perms = get_role_permissions('UNKNOWN_ROLE')
     assert set(unknown_perms) == set(expected_user)
 
@@ -350,13 +292,13 @@ def test_lookup_user_wheel_group_info_custom_table_names(mock_boto3_resource):
     mock_dynamodb_resource = Mock()
     mock_users_table = Mock()
     mock_wheel_groups_table = Mock()
-    
+
     mock_boto3_resource.return_value = mock_dynamodb_resource
     mock_dynamodb_resource.Table.side_effect = lambda name: {
         'test-users': mock_users_table,
         'test-wheel-groups': mock_wheel_groups_table
     }[name]
-    
+
     mock_users_table.scan.return_value = {
         'Items': [{
             'user_id': 'test-user-123',
@@ -365,14 +307,13 @@ def test_lookup_user_wheel_group_info_custom_table_names(mock_boto3_resource):
             'email': 'test@example.com'
         }]
     }
-    
+
     mock_wheel_groups_table.get_item.return_value = {
         'Item': {'wheel_group_name': 'Test Group'}
     }
-    
+
     result = lookup_user_wheel_group_info('test@example.com')
-    
-    # Verify correct table names were used
+
     mock_dynamodb_resource.Table.assert_any_call('test-users')
     mock_dynamodb_resource.Table.assert_any_call('test-wheel-groups')
     assert result['user_id'] == 'test-user-123'
@@ -389,22 +330,18 @@ def test_generate_policy_allow_with_context():
         'role': 'USER',
         'deployment_admin': False
     }
-    
-    policy = generate_policy('test@example.com', 'Allow', 
-                           'arn:aws:execute-api:us-west-2:123:abc/dev/GET/api/v2/wheels', 
+
+    policy = generate_policy('test@example.com', 'Allow',
+                           'arn:aws:execute-api:us-west-2:123:abc/dev/GET/api/v2/wheels',
                            context)
-    
+
     validate_iam_policy_structure(policy)
-    
-    # Validate policy details
+
     assert policy['principalId'] == 'test@example.com'
     assert policy['policyDocument']['Statement'][0]['Effect'] == 'Allow'
     assert policy['policyDocument']['Statement'][0]['Action'] == 'execute-api:Invoke'
-    
-    # Validate wildcard resource pattern
     assert policy['policyDocument']['Statement'][0]['Resource'] == 'arn:aws:execute-api:us-west-2:123:abc/dev/*/*'
-    
-    # Validate context
+
     assert policy['context']['user_id'] == 'test-user-123'
     assert policy['context']['wheel_group_id'] == 'wg-123'
     assert policy['context']['role'] == 'USER'
@@ -413,11 +350,11 @@ def test_generate_policy_allow_with_context():
 
 def test_generate_policy_deny_without_context():
     """Test IAM policy generation for Deny without context"""
-    policy = generate_policy('unauthorized', 'Deny', 
+    policy = generate_policy('unauthorized', 'Deny',
                            'arn:aws:execute-api:us-west-2:123:abc/dev/GET/api/v2/wheels')
-    
+
     validate_iam_policy_structure(policy)
-    
+
     assert policy['principalId'] == 'unauthorized'
     assert policy['policyDocument']['Statement'][0]['Effect'] == 'Deny'
     assert 'context' not in policy
@@ -432,11 +369,11 @@ def test_generate_policy_deployment_admin_context():
         'role': 'DEPLOYMENT_ADMIN',
         'deployment_admin': True
     }
-    
+
     policy = generate_policy('admin@example.com', 'Allow',
                            'arn:aws:execute-api:us-west-2:123:abc/dev/GET/admin/wheel-groups',
                            context)
-    
+
     validate_iam_policy_structure(policy)
     validate_deployment_admin_context(policy['context'])
 
@@ -448,41 +385,39 @@ def test_generate_policy_wildcard_resource_patterns():
         'arn:aws:execute-api:us-west-2:123:abc/prod/POST/api/v2/participants',
         'arn:aws:execute-api:us-east-1:456:xyz/stage/DELETE/admin/wheel-groups/123'
     ]
-    
+
     expected_wildcards = [
         'arn:aws:execute-api:us-west-2:123:abc/dev/*/*',
-        'arn:aws:execute-api:us-west-2:123:abc/prod/*/*', 
+        'arn:aws:execute-api:us-west-2:123:abc/prod/*/*',
         'arn:aws:execute-api:us-east-1:456:xyz/stage/*/*'
     ]
-    
+
     for resource, expected in zip(test_resources, expected_wildcards):
         policy = generate_policy('test', 'Allow', resource)
         actual_resource = policy['policyDocument']['Statement'][0]['Resource']
         assert actual_resource == expected, f"Expected {expected}, got {actual_resource}"
 
 
-def test_generate_policy_malformed_resource():  
+def test_generate_policy_malformed_resource():
     """Test policy generation with malformed resource ARN"""
     malformed_resource = "not-an-arn"
-    
+
     policy = generate_policy('test', 'Allow', malformed_resource)
-    
-    # Should handle gracefully by using original resource
+
     assert policy['policyDocument']['Statement'][0]['Resource'] == malformed_resource
 
 
 def test_generate_policy_context_string_conversion():
     """Test that all context values are converted to strings for API Gateway"""
     context = {
-        'user_id': 123,  # Number
-        'wheel_group_id': None,  # None
-        'deployment_admin': True,  # Boolean
-        'role': 'USER'  # String
+        'user_id': 123,
+        'wheel_group_id': None,
+        'deployment_admin': True,
+        'role': 'USER'
     }
-    
+
     policy = generate_policy('test', 'Allow', 'arn:aws:execute-api:::/*/*', context)
-    
-    # All values should be strings
+
     assert policy['context']['user_id'] == '123'
     assert policy['context']['wheel_group_id'] == 'None'
     assert policy['context']['deployment_admin'] == 'True'
@@ -492,7 +427,7 @@ def test_generate_policy_context_string_conversion():
 def test_generate_policy_no_effect_or_resource():
     """Test policy generation with no effect or resource"""
     policy = generate_policy('test', None, None)
-    
+
     assert policy['principalId'] == 'test'
     assert 'policyDocument' not in policy
     assert 'context' not in policy
@@ -501,9 +436,8 @@ def test_generate_policy_no_effect_or_resource():
 def test_generate_policy_empty_context():
     """Test policy generation with empty context"""
     policy = generate_policy('test', 'Allow', 'arn:aws:execute-api:::/*/*', {})
-    
+
     validate_iam_policy_structure(policy)
-    # Empty context gets filtered out by implementation (correct behavior)
     assert 'context' not in policy or policy.get('context') == {}
 
 
@@ -511,28 +445,28 @@ def test_generate_policy_empty_context():
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('api_gateway_authorizer.lookup_user_wheel_group_info')
-def test_lambda_handler_deployment_admin_success(mock_lookup):
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_lambda_handler_deployment_admin_success(mock_verify, mock_lookup):
     """Test lambda handler with valid deployment admin token"""
-    # Create deployment admin token
     payload = create_valid_jwt_payload(**{'custom:deployment_admin': 'true'})
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_authorizer_event(f"Bearer {token}")
-    
+
     result = lambda_handler(event, create_mock_lambda_context())
-    
+
     validate_iam_policy_structure(result)
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Allow'
     validate_deployment_admin_context(result['context'])
-    
-    # Should not call database lookup for deployment admin
+
     mock_lookup.assert_not_called()
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('api_gateway_authorizer.lookup_user_wheel_group_info')
-def test_lambda_handler_regular_user_success(mock_lookup):
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_lambda_handler_regular_user_success(mock_verify, mock_lookup):
     """Test lambda handler with valid regular user token"""
-    # Mock database lookup
     mock_lookup.return_value = {
         'user_id': 'user-123',
         'wheel_group_id': 'wg-123',
@@ -541,26 +475,25 @@ def test_lambda_handler_regular_user_success(mock_lookup):
         'email': 'user@example.com',
         'name': 'Test User'
     }
-    
+
     payload = create_valid_jwt_payload()
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_authorizer_event(f"Bearer {token}")
-    
+
     result = lambda_handler(event, create_mock_lambda_context())
-    
+
     validate_iam_policy_structure(result)
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Allow'
     validate_regular_user_context(result['context'], 'wg-123', 'USER')
-    
-    # Should call database lookup for regular user
+
     mock_lookup.assert_called_once_with('test@example.com')
 
 
 def test_lambda_handler_missing_authorization_token():
     """Test lambda handler with missing authorization token"""
-    event = {'methodArn': 'arn:aws:execute-api:::/*/*'}  # No authorizationToken
-    
-    # Should return Deny policy, not raise exception (graceful security handling)
+    event = {'methodArn': 'arn:aws:execute-api:::/*/*'}
+
     result = lambda_handler(event, create_mock_lambda_context())
     validate_iam_policy_structure(result)
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Deny'
@@ -570,8 +503,7 @@ def test_lambda_handler_missing_authorization_token():
 def test_lambda_handler_invalid_bearer_token():
     """Test lambda handler with invalid Bearer token format"""
     event = create_authorizer_event('Invalid-Token-Format')
-    
-    # Should return Deny policy, not raise exception (graceful security handling)
+
     result = lambda_handler(event, create_mock_lambda_context())
     validate_iam_policy_structure(result)
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Deny'
@@ -584,8 +516,7 @@ def test_lambda_handler_missing_cognito_configuration():
     payload = create_valid_jwt_payload()
     token = create_jwt_token(payload)
     event = create_authorizer_event(f"Bearer {token}")
-    
-    # Should return Deny policy, not raise exception (graceful security handling)
+
     result = lambda_handler(event, create_mock_lambda_context())
     validate_iam_policy_structure(result)
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Deny'
@@ -593,13 +524,13 @@ def test_lambda_handler_missing_cognito_configuration():
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_lambda_handler_expired_token():
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_lambda_handler_expired_token(mock_verify):
     """Test lambda handler with expired JWT token"""
-    expired_payload = create_valid_jwt_payload(exp=int(time.time()) - 3600)
-    token = create_jwt_token(expired_payload)
+    mock_verify.side_effect = ValueError("Token has expired")
+    token = create_jwt_token(create_valid_jwt_payload())
     event = create_authorizer_event(f"Bearer {token}")
-    
-    # Should return Deny policy, not raise exception (graceful security handling)
+
     result = lambda_handler(event, create_mock_lambda_context())
     validate_iam_policy_structure(result)
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Deny'
@@ -607,14 +538,15 @@ def test_lambda_handler_expired_token():
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_lambda_handler_missing_email_claim():
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_lambda_handler_missing_email_claim(mock_verify):
     """Test lambda handler with token missing email claim"""
     payload = create_valid_jwt_payload()
     del payload['email']
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_authorizer_event(f"Bearer {token}")
-    
-    # Should return Deny policy, not raise exception (graceful security handling)
+
     result = lambda_handler(event, create_mock_lambda_context())
     validate_iam_policy_structure(result)
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Deny'
@@ -622,16 +554,16 @@ def test_lambda_handler_missing_email_claim():
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
+@patch('api_gateway_authorizer.verify_cognito_token')
 @patch('api_gateway_authorizer.lookup_user_wheel_group_info')
-def test_lambda_handler_database_lookup_failure(mock_lookup):
+def test_lambda_handler_database_lookup_failure(mock_lookup, mock_verify):
     """Test lambda handler when database lookup fails"""
+    mock_verify.return_value = create_valid_jwt_payload()
     mock_lookup.side_effect = ValueError("User not found in database")
-    
-    payload = create_valid_jwt_payload()
-    token = create_jwt_token(payload)
+
+    token = create_jwt_token(create_valid_jwt_payload())
     event = create_authorizer_event(f"Bearer {token}")
-    
-    # Should return Deny policy, not raise exception (graceful security handling)
+
     result = lambda_handler(event, create_mock_lambda_context())
     validate_iam_policy_structure(result)
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Deny'
@@ -639,11 +571,12 @@ def test_lambda_handler_database_lookup_failure(mock_lookup):
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_lambda_handler_malformed_jwt_token():
-    """Test lambda handler with malformed JWT token"""
-    event = create_authorizer_event('Bearer invalid.jwt.token')
-    
-    # Should return Deny policy, not raise exception (graceful security handling)
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_lambda_handler_invalid_signature_token(mock_verify):
+    """Test lambda handler with forged JWT token (invalid signature)"""
+    mock_verify.side_effect = ValueError("Invalid token signature")
+    event = create_authorizer_event('Bearer forged.jwt.token')
+
     result = lambda_handler(event, create_mock_lambda_context())
     validate_iam_policy_structure(result)
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Deny'
@@ -653,10 +586,9 @@ def test_lambda_handler_malformed_jwt_token():
 def test_lambda_handler_deny_policy_on_error():
     """Test that lambda handler returns Deny policy on any error"""
     event = create_authorizer_event('Bearer malformed-token')
-    
-    # Should not raise exception, but return Deny policy
+
     result = lambda_handler(event, create_mock_lambda_context())
-    
+
     validate_iam_policy_structure(result)
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Deny'
     assert result['principalId'] == 'user'
@@ -665,87 +597,86 @@ def test_lambda_handler_deny_policy_on_error():
 # Integration & Edge Case Tests (4 tests)
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
+@patch('api_gateway_authorizer.verify_cognito_token')
 @patch('api_gateway_authorizer.lookup_user_wheel_group_info')
-def test_authorizer_end_to_end_regular_user(mock_lookup):
+def test_authorizer_end_to_end_regular_user(mock_lookup, mock_verify):
     """Test complete authorizer flow for regular user"""
-    # Setup database mock
     mock_lookup.return_value = {
         'user_id': 'user-123',
-        'wheel_group_id': 'wg-123', 
+        'wheel_group_id': 'wg-123',
         'wheel_group_name': 'Test Group',
         'role': 'WHEEL_ADMIN',
         'email': 'wheeladmin@example.com',
         'name': 'Wheel Admin'
     }
-    
-    # Create realistic event
+
     payload = create_valid_jwt_payload(user_email='wheeladmin@example.com')
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
-    event = create_authorizer_event(f"Bearer {token}", 
+    event = create_authorizer_event(f"Bearer {token}",
                                   'arn:aws:execute-api:us-west-2:123:api/prod/POST/api/v2/wheels')
-    
+
     result = lambda_handler(event, create_mock_lambda_context())
-    
-    # Validate complete response
-    validate_iam_policy_structure(result) 
+
+    validate_iam_policy_structure(result)
     assert result['principalId'] == 'wheeladmin@example.com'
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Allow'
     assert result['policyDocument']['Statement'][0]['Resource'] == 'arn:aws:execute-api:us-west-2:123:api/prod/*/*'
-    
-    # Validate context contains all expected fields
+
     context = result['context']
     assert context['user_id'] == 'user-123'
     assert context['wheel_group_id'] == 'wg-123'
     assert context['wheel_group_name'] == 'Test Group'
     assert context['role'] == 'WHEEL_ADMIN'
     assert context['deployment_admin'] == 'false'
-    
-    # Verify database lookup was called with correct email
+
     mock_lookup.assert_called_once_with('wheeladmin@example.com')
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_authorizer_end_to_end_deployment_admin():
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_authorizer_end_to_end_deployment_admin(mock_verify):
     """Test complete authorizer flow for deployment admin"""
-    # Create deployment admin token with custom attribute
     payload = create_valid_jwt_payload(
         user_email='admin@example.com',
         name='Deployment Admin',
         **{'custom:deployment_admin': 'true'}
     )
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_authorizer_event(f"Bearer {token}",
                                   'arn:aws:execute-api:us-west-2:123:api/prod/DELETE/admin/wheel-groups/123')
-    
+
     result = lambda_handler(event, create_mock_lambda_context())
-    
-    # Validate deployment admin response
+
     validate_iam_policy_structure(result)
     assert result['principalId'] == 'admin@example.com'
     assert result['policyDocument']['Statement'][0]['Effect'] == 'Allow'
-    
-    # Validate deployment admin context
+
     context = result['context']
     validate_deployment_admin_context(context)
-    assert context['user_id'] == 'test-user-id-123'  # From JWT sub claim
+    assert context['user_id'] == 'test-user-id-123'
 
 
-def test_authorizer_security_boundary_validation():
+@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_authorizer_security_boundary_validation(mock_verify):
     """Test that authorizer properly enforces security boundaries"""
-    # Test 1: Invalid token should return Deny policy
-    invalid_event = create_authorizer_event('Bearer invalid-token')
+    # Test 1: Invalid signature should return Deny policy
+    mock_verify.side_effect = ValueError("Invalid token signature")
+    invalid_event = create_authorizer_event('Bearer forged-token')
     result1 = lambda_handler(invalid_event, create_mock_lambda_context())
-    
+
     assert result1['policyDocument']['Statement'][0]['Effect'] == 'Deny'
     assert result1['principalId'] == 'user'
-    
-    # Test 2: Missing token should return Deny policy (graceful security handling)
+
+    # Test 2: Missing token should return Deny policy
     no_token_event = {'methodArn': 'arn:aws:execute-api:::/*/*'}
     result2 = lambda_handler(no_token_event, create_mock_lambda_context())
     assert result2['policyDocument']['Statement'][0]['Effect'] == 'Deny'
     assert result2['principalId'] == 'user'
-    
-    # Test 3: Token without Bearer prefix should return Deny policy (graceful security handling)
+
+    # Test 3: Token without Bearer prefix should return Deny policy
     malformed_event = create_authorizer_event('InvalidPrefix token-content')
     result3 = lambda_handler(malformed_event, create_mock_lambda_context())
     assert result3['policyDocument']['Statement'][0]['Effect'] == 'Deny'
@@ -753,18 +684,17 @@ def test_authorizer_security_boundary_validation():
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
+@patch('api_gateway_authorizer.verify_cognito_token')
 @patch('api_gateway_authorizer.lookup_user_wheel_group_info')
-def test_authorizer_role_permissions_context_injection(mock_lookup):
+def test_authorizer_role_permissions_context_injection(mock_lookup, mock_verify):
     """Test that authorizer properly injects role permissions context"""
-    # Test different role types and their permissions
     roles_and_permissions = [
         ('USER', ['spin_wheel', 'view_wheels']),
         ('WHEEL_ADMIN', ['create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel', 'view_wheels', 'rig_wheel']),
         ('ADMIN', ['create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel', 'view_wheels', 'manage_users', 'manage_wheel_group', 'rig_wheel'])
     ]
-    
+
     for role, expected_permissions in roles_and_permissions:
-        # Mock database lookup for this role
         mock_lookup.return_value = {
             'user_id': f'{role.lower()}-123',
             'wheel_group_id': 'wg-123',
@@ -774,79 +704,78 @@ def test_authorizer_role_permissions_context_injection(mock_lookup):
             'name': f'Test {role}',
             'permissions': expected_permissions
         }
-        
+
         payload = create_valid_jwt_payload(user_email=f'{role.lower()}@example.com')
+        mock_verify.return_value = payload
         token = create_jwt_token(payload)
         event = create_authorizer_event(f"Bearer {token}")
-        
+
         result = lambda_handler(event, create_mock_lambda_context())
-        
-        # Validate role is properly set in context
+
         assert result['context']['role'] == role
-        
-        # Reset mock for next iteration
+
         mock_lookup.reset_mock()
+        mock_verify.reset_mock()
 
 
 # Security Edge Cases Tests (4 tests)
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_authorizer_handles_token_injection_attempts():
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_authorizer_handles_token_injection_attempts(mock_verify):
     """Test authorizer security against token injection attempts"""
-    # Test SQL injection-like attempts in JWT claims
     malicious_payloads = [
         create_valid_jwt_payload(email="'; DROP TABLE users; --@example.com"),
         create_valid_jwt_payload(sub="<script>alert('xss')</script>"),
         create_valid_jwt_payload(name="'; DELETE FROM wheel_groups; --"),
         create_valid_jwt_payload(**{'custom:deployment_admin': "true'; DROP TABLE users; --"})
     ]
-    
+
     for payload in malicious_payloads:
+        mock_verify.return_value = payload
         token = create_jwt_token(payload)
         event = create_authorizer_event(f"Bearer {token}")
-        
-        # Should either fail validation or handle safely
+
         try:
             result = lambda_handler(event, create_mock_lambda_context())
-            # If it succeeds, validate it's handled safely
             validate_iam_policy_structure(result)
-            # Context values should be strings (safe for API Gateway)
             if 'context' in result:
                 for value in result['context'].values():
                     assert isinstance(value, str)
         except Exception as e:
-            # Expected to fail with malicious input
             assert 'Unauthorized' in str(e)
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_authorizer_prevents_privilege_escalation():
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_authorizer_prevents_privilege_escalation(mock_verify):
     """Test that authorizer prevents privilege escalation attempts"""
     # Test 1: Regular user cannot claim deployment admin via JWT manipulation
-    payload = create_valid_jwt_payload(**{'custom:deployment_admin': 'false'})  # Explicit false
+    payload = create_valid_jwt_payload(**{'custom:deployment_admin': 'false'})
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_authorizer_event(f"Bearer {token}")
-    
+
     with patch('api_gateway_authorizer.lookup_user_wheel_group_info') as mock_lookup:
         mock_lookup.return_value = {
             'user_id': 'user-123',
             'wheel_group_id': 'wg-123',
-            'role': 'USER',  # Database says USER
+            'role': 'USER',
             'email': 'user@example.com',
             'name': 'Regular User'
         }
-        
+
         result = lambda_handler(event, create_mock_lambda_context())
-        
-        # Should be regular user, not deployment admin
+
         assert result['context']['role'] == 'USER'
         assert result['context']['deployment_admin'] == 'false'
-    
+
     # Test 2: Missing deployment admin claim should default to false
-    payload_no_claim = create_valid_jwt_payload()  # No deployment_admin claim
+    payload_no_claim = create_valid_jwt_payload()
+    mock_verify.return_value = payload_no_claim
     token_no_claim = create_jwt_token(payload_no_claim)
     event_no_claim = create_authorizer_event(f"Bearer {token_no_claim}")
-    
+
     with patch('api_gateway_authorizer.lookup_user_wheel_group_info') as mock_lookup:
         mock_lookup.return_value = {
             'user_id': 'user-456',
@@ -855,15 +784,15 @@ def test_authorizer_prevents_privilege_escalation():
             'email': 'user2@example.com',
             'name': 'Another User'
         }
-        
+
         result = lambda_handler(event_no_claim, create_mock_lambda_context())
         assert result['context']['deployment_admin'] == 'false'
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_authorizer_resource_arn_validation():
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_authorizer_resource_arn_validation(mock_verify):
     """Test that authorizer properly validates and processes resource ARNs"""
-    # Test various resource ARN formats
     test_cases = [
         {
             'input': 'arn:aws:execute-api:us-west-2:123:api/dev/GET/api/v2/wheels',
@@ -878,7 +807,7 @@ def test_authorizer_resource_arn_validation():
             'expected': 'arn:aws:execute-api:eu-west-1:789:def/stage/*/*'
         }
     ]
-    
+
     with patch('api_gateway_authorizer.lookup_user_wheel_group_info') as mock_lookup:
         mock_lookup.return_value = {
             'user_id': 'test-user',
@@ -887,49 +816,50 @@ def test_authorizer_resource_arn_validation():
             'email': 'test@example.com',
             'name': 'Test User'
         }
-        
+
         for test_case in test_cases:
             payload = create_valid_jwt_payload()
+            mock_verify.return_value = payload
             token = create_jwt_token(payload)
             event = create_authorizer_event(f"Bearer {token}", test_case['input'])
-            
+
             result = lambda_handler(event, create_mock_lambda_context())
-            
+
             actual_resource = result['policyDocument']['Statement'][0]['Resource']
             assert actual_resource == test_case['expected'], \
                 f"Expected {test_case['expected']}, got {actual_resource} for input {test_case['input']}"
 
 
-def test_authorizer_comprehensive_error_handling():
+@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
+@patch('api_gateway_authorizer.verify_cognito_token')
+def test_authorizer_comprehensive_error_handling(mock_verify):
     """Test comprehensive error handling across all authorizer functions"""
-    # Test decode_jwt_payload_only with various malformed inputs
-    malformed_inputs = [
-        None,
-        123, 
-        [],
-        {},
-        "single-part",
-        "two.parts",
-        "header.invalid-base64-payload.signature",
-        "header.valid-base64-but-not-json.signature"
+    # Test that forged tokens are rejected via signature verification
+    error_cases = [
+        ValueError("Invalid token signature"),
+        ValueError("Token decode failed: Not enough segments"),
+        ValueError("Invalid JWT header: invalid header padding"),
+        ValueError("Unable to fetch JWKS and no cached keys available"),
     ]
-    
-    for malformed_input in malformed_inputs:
-        with pytest.raises((ValueError, AttributeError, TypeError)):
-            decode_jwt_payload_only(malformed_input)
-    
+
+    for error in error_cases:
+        mock_verify.side_effect = error
+        event = create_authorizer_event('Bearer some.fake.token')
+        result = lambda_handler(event, create_mock_lambda_context())
+        validate_iam_policy_structure(result)
+        assert result['policyDocument']['Statement'][0]['Effect'] == 'Deny'
+
     # Test generate_policy with edge case inputs
     edge_cases = [
-        ('', 'Allow', ''),  # Empty strings
-        (None, None, None),  # None values
-        ('test', 'Invalid', 'resource'),  # Invalid effect
+        ('', 'Allow', ''),
+        (None, None, None),
+        ('test', 'Invalid', 'resource'),
     ]
-    
+
     for principal, effect, resource in edge_cases:
-        # Should not raise exception, should handle gracefully
         policy = generate_policy(principal, effect, resource)
         assert 'principalId' in policy
-        
+
         if effect and resource and effect in ['Allow', 'Deny']:
             validate_iam_policy_structure(policy)
 
@@ -937,58 +867,52 @@ def test_authorizer_comprehensive_error_handling():
 # Performance & Scalability Tests (2 tests)
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
+@patch('api_gateway_authorizer.verify_cognito_token')
 @patch('api_gateway_authorizer.lookup_user_wheel_group_info')
-def test_authorizer_performance_with_large_context(mock_lookup):
+def test_authorizer_performance_with_large_context(mock_lookup, mock_verify):
     """Test authorizer performance with large context data"""
-    # Create large context to test string conversion performance
     large_context = {
         'user_id': 'user-123',
-        'wheel_group_id': 'wg-' + 'x' * 100,  # Long ID
-        'wheel_group_name': 'Very Long Wheel Group Name ' * 20,  # Long name
+        'wheel_group_id': 'wg-' + 'x' * 100,
+        'wheel_group_name': 'Very Long Wheel Group Name ' * 20,
         'role': 'ADMIN',
         'email': 'user@example.com',
         'name': 'User with Very Long Name ' * 10
     }
-    
+
     mock_lookup.return_value = large_context
-    
     payload = create_valid_jwt_payload()
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_authorizer_event(f"Bearer {token}")
-    
-    # Should handle large context without issues
+
     result = lambda_handler(event, create_mock_lambda_context())
-    
+
     validate_iam_policy_structure(result)
-    assert len(result['context']['wheel_group_name']) > 100  # Verify large data preserved
-    
-    # All context values should be strings
+    assert len(result['context']['wheel_group_name']) > 100
+
     for key, value in result['context'].items():
         assert isinstance(value, str), f"Context value {key} should be string, got {type(value)}"
 
 
 def test_authorizer_constants_and_configuration_validation():
     """Test that authorizer constants and configurations are properly defined"""
-    # Test that required functions are importable and callable
     assert callable(lambda_handler)
-    assert callable(decode_jwt_payload_only)
-    assert callable(validate_token_basic)
+    assert callable(validate_token)
     assert callable(lookup_user_wheel_group_info)
     assert callable(get_role_permissions)
     assert callable(generate_policy)
-    
-    # Test role permissions constants
+
     all_roles = ['USER', 'WHEEL_ADMIN', 'ADMIN']
     for role in all_roles:
         permissions = get_role_permissions(role)
         assert isinstance(permissions, list)
         assert len(permissions) > 0
         assert all(isinstance(perm, str) for perm in permissions)
-    
-    # Test that USER permissions are subset of WHEEL_ADMIN permissions  
+
     user_perms = set(get_role_permissions('USER'))
     wheel_admin_perms = set(get_role_permissions('WHEEL_ADMIN'))
     admin_perms = set(get_role_permissions('ADMIN'))
-    
+
     assert user_perms.issubset(wheel_admin_perms), "USER permissions should be subset of WHEEL_ADMIN"
     assert wheel_admin_perms.issubset(admin_perms), "WHEEL_ADMIN permissions should be subset of ADMIN"

--- a/api-v2/tests/test_wheel_group_middleware.py
+++ b/api-v2/tests/test_wheel_group_middleware.py
@@ -21,7 +21,7 @@ from base import BadRequestError, NotFoundError
 # Import middleware functions
 from wheel_group_middleware import (
     wheel_group_middleware, require_auth, require_wheel_group_permission,
-    decode_jwt_payload_only, validate_token_basic, lookup_user_wheel_group_info,
+    validate_token, lookup_user_wheel_group_info,
     get_role_permissions, get_wheel_group_context
 )
 
@@ -41,7 +41,7 @@ def create_valid_jwt_payload(user_email="test@example.com", **overrides):
         'sub': 'test-user-id-123',
         'email': user_email,
         'name': 'Test User',
-        'exp': current_time + 3600,  # Expires in 1 hour
+        'exp': current_time + 3600,
         'iss': 'https://cognito-idp.us-west-2.amazonaws.com/us-west-2_TestPool',
         'aud': 'test-client-id',
         'token_use': 'id',
@@ -53,17 +53,11 @@ def create_valid_jwt_payload(user_email="test@example.com", **overrides):
 
 
 def create_jwt_token(payload):
-    """Create a mock JWT token with the given payload"""
-    # Create header (not validated in this implementation)
+    """Create a mock JWT token with the given payload (for use with mocked verification)"""
     header = {'alg': 'RS256', 'typ': 'JWT'}
     header_encoded = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip('=')
-    
-    # Encode payload
     payload_encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
-    
-    # Create signature (not validated in this implementation)
     signature = base64.urlsafe_b64encode(b'fake-signature').decode().rstrip('=')
-    
     return f"{header_encoded}.{payload_encoded}.{signature}"
 
 
@@ -71,10 +65,10 @@ def create_api_event(token=None, path="/api/v2/wheels", method="GET", headers=No
     """Create a mock API Gateway event"""
     if headers is None:
         headers = {}
-    
+
     if token:
         headers['Authorization'] = f"Bearer {token}"
-    
+
     return {
         'path': path,
         'httpMethod': method,
@@ -92,7 +86,7 @@ def validate_error_response(response, expected_status=401):
     assert response['headers']['Content-Type'] == 'application/json'
     assert response['headers']['Access-Control-Allow-Origin'] == '*'
     assert 'body' in response
-    
+
     body = json.loads(response['body'])
     assert 'error' in body
     return body
@@ -102,93 +96,56 @@ def validate_success_event(event):
     """Validate successful authentication event structure"""
     assert 'wheel_group_context' in event
     assert 'user_info' in event
-    
+
     context = event['wheel_group_context']
     assert 'user_id' in context
     assert 'email' in context
     assert 'role' in context
     assert 'permissions' in context
     assert 'deployment_admin' in context
-    
+
     return context
 
 
-# JWT Validation Tests (6 tests)
+# JWT Verification Tests (4 tests)
 
-def test_decode_jwt_payload_only_valid_token():
-    """Test JWT payload decoding with valid token"""
-    payload = create_valid_jwt_payload()
-    token = create_jwt_token(payload)
-    
-    decoded = decode_jwt_payload_only(token)
-    
-    assert decoded['sub'] == payload['sub']
-    assert decoded['email'] == payload['email'] 
-    assert decoded['exp'] == payload['exp']
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_validate_token_delegates_to_jwt_verifier(mock_verify):
+    """Test that validate_token delegates to jwt_verifier.verify_cognito_token"""
+    expected_payload = create_valid_jwt_payload()
+    mock_verify.return_value = expected_payload
 
+    result = validate_token('fake.token.here', 'us-west-2_TestPool', 'test-client-id')
 
-def test_decode_jwt_payload_only_invalid_format():
-    """Test JWT decoding fails with malformed token"""
-    invalid_tokens = [
-        "invalid.token",
-        "invalid.token.signature.extra",
-        "not-base64.not-base64.not-base64",
-        "",
-        "invalid"
-    ]
-    
-    for invalid_token in invalid_tokens:
-        with pytest.raises(ValueError, match="Failed to decode JWT payload"):
-            decode_jwt_payload_only(invalid_token)
+    mock_verify.assert_called_once_with('fake.token.here', 'us-west-2_TestPool', 'test-client-id')
+    assert result == expected_payload
 
 
-@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_validate_token_basic_valid_token():
-    """Test basic token validation with valid token"""
-    payload = create_valid_jwt_payload()
-    token = create_jwt_token(payload)
-    
-    result = validate_token_basic(token, 'us-west-2_TestPool', 'test-client-id')
-    
-    assert result['sub'] == payload['sub']
-    assert result['email'] == payload['email']
-    assert result['exp'] == payload['exp']
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_validate_token_propagates_expired_error(mock_verify):
+    """Test that validate_token propagates expiration errors"""
+    mock_verify.side_effect = ValueError("Token has expired")
 
-
-@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_validate_token_basic_expired_token():
-    """Test token validation fails with expired token"""
-    expired_time = int(time.time()) - 3600
-    payload = create_valid_jwt_payload(exp=expired_time)
-    token = create_jwt_token(payload)
-    
     with pytest.raises(ValueError, match="Token has expired"):
-        validate_token_basic(token, 'us-west-2_TestPool', 'test-client-id')
+        validate_token('expired.token.here', 'us-west-2_TestPool', 'test-client-id')
 
 
-@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_validate_token_basic_missing_claims():
-    """Test token validation fails with missing required claims"""
-    base_payload = create_valid_jwt_payload()
-    required_claims = ['sub', 'exp', 'iss', 'aud']
-    
-    for claim in required_claims:
-        payload = base_payload.copy()
-        del payload[claim]
-        token = create_jwt_token(payload)
-        
-        with pytest.raises(ValueError, match=f"Missing required claim: {claim}"):
-            validate_token_basic(token, 'us-west-2_TestPool', 'test-client-id')
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_validate_token_rejects_invalid_signature(mock_verify):
+    """Test that validate_token rejects tokens with invalid signatures"""
+    mock_verify.side_effect = ValueError("Invalid token signature")
+
+    with pytest.raises(ValueError, match="Invalid token signature"):
+        validate_token('forged.token.here', 'us-west-2_TestPool', 'test-client-id')
 
 
-@patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_validate_token_basic_cognito_typo_handling():
-    """Test token validation handles AWS Cognito service typo in issuer"""
-    payload = create_valid_jwt_payload(iss='https://cognitm-idp.us-west-2.amazonaws.com/us-west-2_TestPool')
-    token = create_jwt_token(payload)
-    
-    result = validate_token_basic(token, 'us-west-2_TestPool', 'test-client-id')
-    assert result['sub'] == payload['sub']
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_validate_token_rejects_missing_claims(mock_verify):
+    """Test that validate_token rejects tokens with missing claims"""
+    mock_verify.side_effect = ValueError("Token verification failed: Token is missing the 'sub' claim")
+
+    with pytest.raises(ValueError, match="Token verification failed"):
+        validate_token('bad.token.here', 'us-west-2_TestPool', 'test-client-id')
 
 
 # Database Integration Tests (4 tests)
@@ -198,12 +155,12 @@ def test_lookup_user_wheel_group_info_user_not_found(mock_boto3_resource):
     """Test user lookup when user doesn't exist"""
     mock_dynamodb_resource = Mock()
     mock_users_table = Mock()
-    
+
     mock_boto3_resource.return_value = mock_dynamodb_resource
     mock_dynamodb_resource.Table.return_value = mock_users_table
-    
+
     mock_users_table.scan.return_value = {'Items': []}
-    
+
     with pytest.raises(ValueError, match="User not found in database: nonexistent@example.com"):
         lookup_user_wheel_group_info('nonexistent@example.com')
 
@@ -213,49 +170,45 @@ def test_lookup_user_wheel_group_info_database_error(mock_boto3_resource):
     """Test user lookup handles database errors gracefully"""
     mock_dynamodb_resource = Mock()
     mock_users_table = Mock()
-    
+
     mock_boto3_resource.return_value = mock_dynamodb_resource
     mock_dynamodb_resource.Table.return_value = mock_users_table
-    
+
     mock_users_table.scan.side_effect = Exception("DynamoDB connection failed")
-    
+
     with pytest.raises(ValueError, match="Failed to lookup user wheel group info"):
         lookup_user_wheel_group_info('test@example.com')
 
 
 def test_get_role_permissions_all_roles():
     """Test role permissions mapping for all role types"""
-    # Test DEPLOYMENT_ADMIN permissions (most comprehensive)
     deployment_admin_perms = get_role_permissions('DEPLOYMENT_ADMIN')
     expected_deployment_admin = [
         'view_all_wheel_groups', 'delete_wheel_group', 'manage_deployment',
-        'create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel', 
+        'create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel',
         'view_wheels', 'manage_users', 'manage_wheel_group', 'rig_wheel'
     ]
     for perm in expected_deployment_admin:
         assert deployment_admin_perms[perm] == True
-    
-    # Test ADMIN permissions
+
     admin_perms = get_role_permissions('ADMIN')
     expected_admin = [
-        'create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel', 
+        'create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel',
         'view_wheels', 'manage_users', 'manage_wheel_group', 'rig_wheel'
     ]
     for perm in expected_admin:
         assert admin_perms[perm] == True
-    
-    # Test WHEEL_ADMIN permissions
+
     wheel_admin_perms = get_role_permissions('WHEEL_ADMIN')
     expected_wheel_admin = [
-        'create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel', 
+        'create_wheel', 'delete_wheel', 'manage_participants', 'spin_wheel',
         'view_wheels', 'rig_wheel'
     ]
     for perm in expected_wheel_admin:
         assert wheel_admin_perms[perm] == True
     assert wheel_admin_perms['manage_users'] == False
     assert wheel_admin_perms['manage_wheel_group'] == False
-    
-    # Test USER permissions
+
     user_perms = get_role_permissions('USER')
     assert user_perms['spin_wheel'] == True
     assert user_perms['view_wheels'] == True
@@ -270,9 +223,9 @@ def test_get_role_permissions_all_roles():
 def test_wheel_group_middleware_missing_authorization():
     """Test middleware with missing Authorization header"""
     event = create_api_event()
-    
+
     response = wheel_group_middleware(event, create_mock_lambda_context())
-    
+
     error_body = validate_error_response(response, 401)
     assert 'Missing or invalid Authorization header' in error_body['error']
 
@@ -282,9 +235,9 @@ def test_wheel_group_middleware_invalid_bearer_format():
     """Test middleware with invalid Bearer token format"""
     event = create_api_event()
     event['headers']['Authorization'] = 'Invalid-Token-Format'
-    
+
     response = wheel_group_middleware(event, create_mock_lambda_context())
-    
+
     error_body = validate_error_response(response, 401)
     assert 'Missing or invalid Authorization header' in error_body['error']
 
@@ -295,50 +248,54 @@ def test_wheel_group_middleware_missing_cognito_config():
     payload = create_valid_jwt_payload()
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
+
     response = wheel_group_middleware(event, create_mock_lambda_context())
-    
-    # Implementation returns 401 (Authentication failed) not 500
+
     error_body = validate_error_response(response, 401)
     assert 'Authentication failed' in error_body['error']
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_wheel_group_middleware_expired_token():
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_wheel_group_middleware_expired_token(mock_verify):
     """Test middleware with expired JWT token"""
-    expired_payload = create_valid_jwt_payload(exp=int(time.time()) - 3600)
-    token = create_jwt_token(expired_payload)
+    mock_verify.side_effect = ValueError("Token has expired")
+    token = create_jwt_token(create_valid_jwt_payload())
     event = create_api_event(token)
-    
+
     response = wheel_group_middleware(event, create_mock_lambda_context())
-    
+
     error_body = validate_error_response(response, 401)
     assert 'Authentication failed' in error_body['error']
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_wheel_group_middleware_missing_email_claim():
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_wheel_group_middleware_missing_email_claim(mock_verify):
     """Test middleware with token missing email claim"""
     payload = create_valid_jwt_payload()
     del payload['email']
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
+
     response = wheel_group_middleware(event, create_mock_lambda_context())
-    
+
     error_body = validate_error_response(response, 401)
     assert 'Token missing required claims' in error_body['error']
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_wheel_group_middleware_deployment_admin_success():
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_wheel_group_middleware_deployment_admin_success(mock_verify):
     """Test middleware with valid deployment admin token"""
     payload = create_valid_jwt_payload(**{'custom:deployment_admin': 'true'})
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
+
     result = wheel_group_middleware(event, create_mock_lambda_context())
-    
+
     context = validate_success_event(result)
     assert context['role'] == 'DEPLOYMENT_ADMIN'
     assert context['deployment_admin'] == True
@@ -349,7 +306,8 @@ def test_wheel_group_middleware_deployment_admin_success():
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_wheel_group_middleware_regular_user_success(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_wheel_group_middleware_regular_user_success(mock_verify, mock_lookup):
     """Test middleware with valid regular user token"""
     mock_lookup.return_value = {
         'user_id': 'user-123',
@@ -359,13 +317,14 @@ def test_wheel_group_middleware_regular_user_success(mock_lookup):
         'email': 'user@example.com',
         'name': 'Test User'
     }
-    
+
     payload = create_valid_jwt_payload()
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
+
     result = wheel_group_middleware(event, create_mock_lambda_context())
-    
+
     context = validate_success_event(result)
     assert context['role'] == 'WHEEL_ADMIN'
     assert context['deployment_admin'] == False
@@ -377,16 +336,18 @@ def test_wheel_group_middleware_regular_user_success(mock_lookup):
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_wheel_group_middleware_auth_me_endpoint_fallback(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_wheel_group_middleware_auth_me_endpoint_fallback(mock_verify, mock_lookup):
     """Test middleware allows /auth/me endpoint even without wheel group"""
     mock_lookup.side_effect = ValueError("User not found in database")
-    
+
     payload = create_valid_jwt_payload()
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token, path="/auth/me")
-    
+
     result = wheel_group_middleware(event, create_mock_lambda_context())
-    
+
     context = validate_success_event(result)
     assert context['role'] == 'USER'
     assert context['deployment_admin'] == False
@@ -396,27 +357,31 @@ def test_wheel_group_middleware_auth_me_endpoint_fallback(mock_lookup):
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_wheel_group_middleware_database_lookup_failure(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_wheel_group_middleware_database_lookup_failure(mock_verify, mock_lookup):
     """Test middleware when database lookup fails for non-auth endpoint"""
     mock_lookup.side_effect = ValueError("User not found in database")
-    
+
     payload = create_valid_jwt_payload()
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token, path="/api/v2/wheels")
-    
+
     response = wheel_group_middleware(event, create_mock_lambda_context())
-    
+
     error_body = validate_error_response(response, 401)
     assert 'User not associated with any wheel group' in error_body['error']
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_wheel_group_middleware_malformed_jwt():
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_wheel_group_middleware_malformed_jwt(mock_verify):
     """Test middleware with malformed JWT token"""
+    mock_verify.side_effect = ValueError("Token decode failed: Not enough segments")
     event = create_api_event('invalid.jwt.token')
-    
+
     response = wheel_group_middleware(event, create_mock_lambda_context())
-    
+
     error_body = validate_error_response(response, 401)
     assert 'Authentication failed' in error_body['error']
 
@@ -425,7 +390,8 @@ def test_wheel_group_middleware_malformed_jwt():
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_require_auth_decorator_success(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_require_auth_decorator_success(mock_verify, mock_lookup):
     """Test @require_auth decorator with valid authentication"""
     mock_lookup.return_value = {
         'user_id': 'user-123',
@@ -435,17 +401,18 @@ def test_require_auth_decorator_success(mock_lookup):
         'email': 'user@example.com',
         'name': 'Test User'
     }
-    
+
     @require_auth()
     def test_handler(event, context):
         return {'statusCode': 200, 'body': json.dumps({'message': 'success'})}
-    
+
     payload = create_valid_jwt_payload()
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
+
     result = test_handler(event, create_mock_lambda_context())
-    
+
     assert result['statusCode'] == 200
     body = json.loads(result['body'])
     assert body['message'] == 'success'
@@ -457,18 +424,19 @@ def test_require_auth_decorator_failure():
     @require_auth()
     def test_handler(event, context):
         return {'statusCode': 200, 'body': json.dumps({'message': 'success'})}
-    
+
     event = create_api_event()  # No token
-    
+
     result = test_handler(event, create_mock_lambda_context())
-    
+
     error_body = validate_error_response(result, 401)
     assert 'Missing or invalid Authorization header' in error_body['error']
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_require_wheel_group_permission_success(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_require_wheel_group_permission_success(mock_verify, mock_lookup):
     """Test @require_wheel_group_permission decorator with sufficient permissions"""
     mock_lookup.return_value = {
         'user_id': 'admin-123',
@@ -478,17 +446,18 @@ def test_require_wheel_group_permission_success(mock_lookup):
         'email': 'admin@example.com',
         'name': 'Test Admin'
     }
-    
+
     @require_wheel_group_permission('create_wheel')
     def test_handler(event, context):
         return {'statusCode': 200, 'body': json.dumps({'message': 'wheel created'})}
-    
+
     payload = create_valid_jwt_payload(user_email='admin@example.com')
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
+
     result = test_handler(event, create_mock_lambda_context())
-    
+
     assert result['statusCode'] == 200
     body = json.loads(result['body'])
     assert body['message'] == 'wheel created'
@@ -496,27 +465,29 @@ def test_require_wheel_group_permission_success(mock_lookup):
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_require_wheel_group_permission_insufficient_permissions(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_require_wheel_group_permission_insufficient_permissions(mock_verify, mock_lookup):
     """Test @require_wheel_group_permission decorator with insufficient permissions"""
     mock_lookup.return_value = {
         'user_id': 'user-123',
         'wheel_group_id': 'wg-123',
         'wheel_group_name': 'Test Group',
-        'role': 'USER',  # USER role cannot create wheels
+        'role': 'USER',
         'email': 'user@example.com',
         'name': 'Test User'
     }
-    
+
     @require_wheel_group_permission('create_wheel')
     def test_handler(event, context):
         return {'statusCode': 200, 'body': json.dumps({'message': 'wheel created'})}
-    
+
     payload = create_valid_jwt_payload()
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
+
     result = test_handler(event, create_mock_lambda_context())
-    
+
     error_body = validate_error_response(result, 403)
     assert 'Insufficient permissions' in error_body['error']
     assert 'Required: create_wheel' in error_body['error']
@@ -529,18 +500,19 @@ def test_require_wheel_group_permission_auth_failure():
     @require_wheel_group_permission('spin_wheel')
     def test_handler(event, context):
         return {'statusCode': 200, 'body': json.dumps({'message': 'wheel spun'})}
-    
+
     event = create_api_event()  # No token
-    
+
     result = test_handler(event, create_mock_lambda_context())
-    
+
     error_body = validate_error_response(result, 401)
     assert 'Missing or invalid Authorization header' in error_body['error']
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_nested_decorators_success(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_nested_decorators_success(mock_verify, mock_lookup):
     """Test nested @require_auth and @require_wheel_group_permission decorators"""
     mock_lookup.return_value = {
         'user_id': 'wheel-admin-123',
@@ -550,18 +522,19 @@ def test_nested_decorators_success(mock_lookup):
         'email': 'wheeladmin@example.com',
         'name': 'Test Wheel Admin'
     }
-    
+
     @require_auth()
     @require_wheel_group_permission('rig_wheel')
     def test_handler(event, context):
         return {'statusCode': 200, 'body': json.dumps({'message': 'wheel rigged'})}
-    
+
     payload = create_valid_jwt_payload(user_email='wheeladmin@example.com')
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
+
     result = test_handler(event, create_mock_lambda_context())
-    
+
     assert result['statusCode'] == 200
     body = json.loads(result['body'])
     assert body['message'] == 'wheel rigged'
@@ -569,30 +542,31 @@ def test_nested_decorators_success(mock_lookup):
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_deployment_admin_permissions_override(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_deployment_admin_permissions_override(mock_verify, mock_lookup):
     """Test deployment admin has all permissions regardless of wheel group"""
-    # Don't call database lookup for deployment admin
     @require_wheel_group_permission('delete_wheel_group')
     def test_handler(event, context):
         return {'statusCode': 200, 'body': json.dumps({'message': 'wheel group deleted'})}
-    
+
     payload = create_valid_jwt_payload(**{'custom:deployment_admin': 'true'})
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
+
     result = test_handler(event, create_mock_lambda_context())
-    
+
     assert result['statusCode'] == 200
     body = json.loads(result['body'])
     assert body['message'] == 'wheel group deleted'
-    
-    # Should not call database lookup for deployment admin
+
     mock_lookup.assert_not_called()
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_multiple_permission_checks(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_multiple_permission_checks(mock_verify, mock_lookup):
     """Test multiple different permission requirements"""
     mock_lookup.return_value = {
         'user_id': 'admin-123',
@@ -602,25 +576,25 @@ def test_multiple_permission_checks(mock_lookup):
         'email': 'admin@example.com',
         'name': 'Test Admin'
     }
-    
-    # Test each permission type
+
     permissions_to_test = [
-        'create_wheel', 'delete_wheel', 'manage_participants', 
-        'spin_wheel', 'view_wheels', 'manage_users', 
+        'create_wheel', 'delete_wheel', 'manage_participants',
+        'spin_wheel', 'view_wheels', 'manage_users',
         'manage_wheel_group', 'rig_wheel'
     ]
-    
+
     payload = create_valid_jwt_payload(user_email='admin@example.com')
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
-    
+
     for permission in permissions_to_test:
         @require_wheel_group_permission(permission)
         def test_permission_handler(event, context):
             return {'statusCode': 200, 'body': json.dumps({'permission': permission})}
-        
+
         event = create_api_event(token)
         result = test_permission_handler(event, create_mock_lambda_context())
-        
+
         assert result['statusCode'] == 200
         body = json.loads(result['body'])
         assert body['permission'] == permission
@@ -630,7 +604,8 @@ def test_multiple_permission_checks(mock_lookup):
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_get_wheel_group_context_success(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_get_wheel_group_context_success(mock_verify, mock_lookup):
     """Test get_wheel_group_context helper function"""
     mock_lookup.return_value = {
         'user_id': 'user-123',
@@ -640,17 +615,16 @@ def test_get_wheel_group_context_success(mock_lookup):
         'email': 'user@example.com',
         'name': 'Test User'
     }
-    
+
     payload = create_valid_jwt_payload()
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
-    # Process through middleware first
+
     result = wheel_group_middleware(event, create_mock_lambda_context())
-    
-    # Test get_wheel_group_context function
+
     context = get_wheel_group_context(result)
-    
+
     assert context is not None
     assert context['user_id'] == 'user-123'
     assert context['wheel_group_id'] == 'wg-123'
@@ -660,10 +634,10 @@ def test_get_wheel_group_context_success(mock_lookup):
 
 def test_get_wheel_group_context_no_context():
     """Test get_wheel_group_context with event missing context"""
-    event = {'path': '/test'}  # No wheel_group_context
-    
+    event = {'path': '/test'}
+
     context = get_wheel_group_context(event)
-    
+
     assert context is None
 
 
@@ -671,7 +645,8 @@ def test_get_wheel_group_context_no_context():
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_middleware_handles_malicious_payloads(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_middleware_handles_malicious_payloads(mock_verify, mock_lookup):
     """Test middleware security against malicious JWT payloads"""
     mock_lookup.return_value = {
         'user_id': 'user-123',
@@ -681,27 +656,24 @@ def test_middleware_handles_malicious_payloads(mock_lookup):
         'email': 'test@example.com',
         'name': 'Test User'
     }
-    
-    # Test malicious payloads that could attempt injection
+
     malicious_payloads = [
         create_valid_jwt_payload(email="'; DROP TABLE users; --@example.com"),
         create_valid_jwt_payload(sub="<script>alert('xss')</script>"),
         create_valid_jwt_payload(name="'; DELETE FROM wheel_groups; --"),
     ]
-    
+
     for payload in malicious_payloads:
+        mock_verify.return_value = payload
         token = create_jwt_token(payload)
         event = create_api_event(token)
-        
-        # Should either fail validation or handle safely
+
         try:
             result = wheel_group_middleware(event, create_mock_lambda_context())
             if 'wheel_group_context' in result:
-                # If successful, ensure values are safely handled
                 context = result['wheel_group_context']
                 for key, value in context.items():
                     if key == 'permissions':
-                        # Permissions is a dictionary of boolean values
                         assert isinstance(value, dict), f"Permissions should be a dictionary"
                         for perm_key, perm_value in value.items():
                             assert isinstance(perm_key, str), f"Permission key should be string"
@@ -709,62 +681,60 @@ def test_middleware_handles_malicious_payloads(mock_lookup):
                     else:
                         assert isinstance(value, (str, bool, type(None))), f"Context value {key} should be safe type"
         except (ValueError, KeyError) as e:
-            # Expected for malicious input - specific exceptions only
             pytest.fail(f"Unexpected exception with malicious payload: {e}")
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_middleware_prevents_role_escalation(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_middleware_prevents_role_escalation(mock_verify, mock_lookup):
     """Test that middleware prevents role escalation attempts"""
-    # Database says USER, but JWT claims ADMIN
     mock_lookup.return_value = {
         'user_id': 'user-123',
         'wheel_group_id': 'wg-123',
         'wheel_group_name': 'Test Group',
-        'role': 'USER',  # Database role is USER
+        'role': 'USER',
         'email': 'user@example.com',
         'name': 'Test User'
     }
-    
-    # JWT claims different role (attempt at escalation)
+
     payload = create_valid_jwt_payload()
     payload['custom:role'] = 'ADMIN'  # Attempt to claim admin role
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
+
     result = wheel_group_middleware(event, create_mock_lambda_context())
-    
+
     context = validate_success_event(result)
-    # Should use database role, not JWT role claim
     assert context['role'] == 'USER'
     assert context['permissions']['create_wheel'] == False
 
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
-def test_middleware_header_case_insensitive():
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_middleware_header_case_insensitive(mock_verify):
     """Test middleware handles Authorization header case variations"""
     variations = [
         'Authorization',
-        'authorization', 
+        'authorization',
         'AUTHORIZATION'
     ]
-    
+
     payload = create_valid_jwt_payload(**{'custom:deployment_admin': 'true'})
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
-    
+
     for header_name in variations:
         event = create_api_event()
         event['headers'] = {header_name: f'Bearer {token}'}
-        
+
         result = wheel_group_middleware(event, create_mock_lambda_context())
-        
+
         if header_name == 'Authorization' or header_name == 'authorization':
-            # Should succeed for 'Authorization' and 'authorization' (implementation supports both)
             context = validate_success_event(result)
             assert context['role'] == 'DEPLOYMENT_ADMIN'
         else:
-            # Should fail for 'AUTHORIZATION' (implementation only checks these two)
             error_body = validate_error_response(result, 401)
             assert 'Missing or invalid Authorization header' in error_body['error']
 
@@ -773,9 +743,9 @@ def test_middleware_header_case_insensitive():
 
 @patch.dict(os.environ, {'COGNITO_USER_POOL_ID': 'us-west-2_TestPool', 'COGNITO_CLIENT_ID': 'test-client-id'})
 @patch('wheel_group_middleware.lookup_user_wheel_group_info')
-def test_middleware_performance_large_permissions(mock_lookup):
+@patch('wheel_group_middleware.verify_cognito_token')
+def test_middleware_performance_large_permissions(mock_verify, mock_lookup):
     """Test middleware performance with comprehensive permission sets"""
-    # Create large permission set for deployment admin
     mock_lookup.return_value = {
         'user_id': 'admin-123',
         'wheel_group_id': 'wg-123',
@@ -784,20 +754,19 @@ def test_middleware_performance_large_permissions(mock_lookup):
         'email': 'admin@example.com',
         'name': 'Test Admin with Very Long Name ' * 10
     }
-    
+
     payload = create_valid_jwt_payload(user_email='admin@example.com')
+    mock_verify.return_value = payload
     token = create_jwt_token(payload)
     event = create_api_event(token)
-    
+
     result = wheel_group_middleware(event, create_mock_lambda_context())
-    
+
     context = validate_success_event(result)
-    
-    # Verify large data is handled correctly
+
     assert len(context['wheel_group_name']) > 100
     assert len(context['name']) > 100
-    
-    # Verify all permissions are boolean
+
     permissions = context['permissions']
     for perm_name, perm_value in permissions.items():
         assert isinstance(perm_value, bool), f"Permission {perm_name} should be boolean"
@@ -805,17 +774,14 @@ def test_middleware_performance_large_permissions(mock_lookup):
 
 def test_middleware_constants_and_configuration():
     """Test middleware constants and configuration validation"""
-    # Test that required functions are importable and callable
     assert callable(wheel_group_middleware)
     assert callable(require_auth)
     assert callable(require_wheel_group_permission)
-    assert callable(decode_jwt_payload_only)
-    assert callable(validate_token_basic)
+    assert callable(validate_token)
     assert callable(lookup_user_wheel_group_info)
     assert callable(get_role_permissions)
     assert callable(get_wheel_group_context)
-    
-    # Test role permissions constants
+
     all_roles = ['USER', 'WHEEL_ADMIN', 'ADMIN', 'DEPLOYMENT_ADMIN']
     for role in all_roles:
         permissions = get_role_permissions(role)
@@ -823,20 +789,17 @@ def test_middleware_constants_and_configuration():
         assert len(permissions) > 0
         assert all(isinstance(perm_name, str) for perm_name in permissions.keys())
         assert all(isinstance(perm_value, bool) for perm_value in permissions.values())
-    
-    # Test permission hierarchy
+
     user_perms = get_role_permissions('USER')
     wheel_admin_perms = get_role_permissions('WHEEL_ADMIN')
     admin_perms = get_role_permissions('ADMIN')
     deployment_admin_perms = get_role_permissions('DEPLOYMENT_ADMIN')
-    
-    # USER permissions should be most restrictive
+
     user_true_perms = [k for k, v in user_perms.items() if v]
     wheel_admin_true_perms = [k for k, v in wheel_admin_perms.items() if v]
     admin_true_perms = [k for k, v in admin_perms.items() if v]
     deployment_admin_true_perms = [k for k, v in deployment_admin_perms.items() if v]
-    
-    # Check permission hierarchy
+
     assert len(user_true_perms) <= len(wheel_admin_true_perms), "USER should have fewer permissions than WHEEL_ADMIN"
     assert len(wheel_admin_true_perms) <= len(admin_true_perms), "WHEEL_ADMIN should have fewer permissions than ADMIN"
     assert len(admin_true_perms) <= len(deployment_admin_true_perms), "ADMIN should have fewer permissions than DEPLOYMENT_ADMIN"

--- a/api-v2/wheel_group_middleware.py
+++ b/api-v2/wheel_group_middleware.py
@@ -4,7 +4,6 @@ instead of relying on JWT custom attributes
 """
 
 import json
-import base64
 import os
 import time
 import boto3
@@ -15,65 +14,15 @@ from typing import Dict, Any, Optional
 # Initialize DynamoDB client
 dynamodb = boto3.resource('dynamodb', region_name=os.environ.get('AWS_DEFAULT_REGION', 'us-west-2'))
 
-def decode_jwt_payload_only(token: str) -> Dict[str, Any]:
-    """
-    Decode JWT payload without signature verification
-    """
-    try:
-        # Split token into parts
-        parts = token.split('.')
-        if len(parts) != 3:
-            raise ValueError("Invalid JWT format")
-        
-        # Decode payload (middle part)
-        payload_encoded = parts[1]
-        # Add padding if necessary
-        payload_encoded += '=' * (4 - len(payload_encoded) % 4)
-        payload_bytes = base64.urlsafe_b64decode(payload_encoded)
-        payload = json.loads(payload_bytes.decode('utf-8'))
-        
-        return payload
-    except Exception as e:
-        raise ValueError(f"Failed to decode JWT payload: {str(e)}")
+from jwt_verifier import verify_cognito_token
 
-def validate_token_basic(token: str, user_pool_id: str, client_id: str) -> Dict[str, Any]:
+def validate_token(token: str, user_pool_id: str, client_id: str) -> Dict[str, Any]:
     """
-    Basic JWT token validation without signature verification
+    Validate a Cognito JWT token with full cryptographic signature verification.
+    Uses the shared jwt_verifier module which fetches JWKS from the Cognito
+    User Pool and verifies the RS256 signature before trusting any claims.
     """
-    try:
-        payload = decode_jwt_payload_only(token)
-        
-        # Basic validations
-        required_claims = ['sub', 'exp', 'iss', 'aud']
-        for claim in required_claims:
-            if claim not in payload:
-                raise ValueError(f"Missing required claim: {claim}")
-        
-        # Check issuer format (handle AWS Cognito service issue with typo)
-        region = user_pool_id.split('_')[0]
-        expected_iss = f"https://cognito-idp.{region}.amazonaws.com/{user_pool_id}"
-        typo_iss = f"https://cognitm-idp.{region}.amazonaws.com/{user_pool_id}"  # AWS service issue
-        
-        if payload['iss'] not in [expected_iss, typo_iss]:
-            raise ValueError(f"Invalid issuer: {payload['iss']}. Expected: {expected_iss}")
-        
-        # Check audience
-        if payload['aud'] != client_id:
-            raise ValueError(f"Invalid audience: {payload['aud']}")
-        
-        # Check token type
-        if payload.get('token_use') != 'id':
-            raise ValueError(f"Invalid token use: {payload.get('token_use')}")
-        
-        # Check expiration (basic check)
-        current_time = int(time.time())
-        if payload['exp'] < current_time:
-            raise ValueError("Token has expired")
-        
-        return payload
-        
-    except Exception as e:
-        raise ValueError(f"Token validation failed: {str(e)}")
+    return verify_cognito_token(token, user_pool_id, client_id)
 
 def lookup_user_wheel_group_info(user_email: str) -> Dict[str, Any]:
     """
@@ -158,8 +107,8 @@ def wheel_group_middleware(event, context):
                 'body': json.dumps({'error': 'Cognito configuration missing'})
             }
         
-        # Validate token (basic validation)
-        payload = validate_token_basic(token, user_pool_id, client_id)
+        # Verify JWT with cryptographic signature validation
+        payload = validate_token(token, user_pool_id, client_id)
         
         # Get user info from JWT
         user_id = payload.get('sub')

--- a/lambda-layer-requirements.txt
+++ b/lambda-layer-requirements.txt
@@ -2,7 +2,7 @@
 # Excludes libraries already provided by AWS Lambda runtime
 
 # Don't include boto3/botocore - AWS Lambda runtime provides these
-# Don't include cryptography - causes ELF header issues and not needed
 
-# Only include what's absolutely necessary
-pyjwt>=2.8.0
+# JWT signature verification
+pyjwt[crypto]>=2.8.0
+cryptography>=41.0.0


### PR DESCRIPTION
*Description of changes:* 
The insecure decode_jwt_payload_only() and validate_token_basic() functions that only base64-decoded JWT payloads without verifying signatures have been replaced with proper RS256 cryptographic verification via the new jwt_verifier.py module

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
