### PR TITLE
fix(security): prevent stored XSS via participant_url

### DIFF
--- a/api-v2/participant_operations.py
+++ b/api-v2/participant_operations.py
@@ -4,6 +4,7 @@
 import json
 from typing import Dict, Any, List
 from decimal import Decimal
+from urllib.parse import urlparse
 from base import BadRequestError, NotFoundError
 from wheel_group_middleware import require_wheel_group_permission, get_wheel_group_context
 from utils_v2 import (
@@ -42,12 +43,18 @@ PARTICIPANT_CONSTRAINTS = {
     'DEFAULT_MAX_PARTICIPANTS': 100
 }
 
+# Only absolute http/https URLs are permitted for participant_url. This blocks
+# dangerous schemes (javascript:, data:, vbscript:, file:) that lead to stored
+# XSS when the URL is later passed to window.open()/<a href> in the frontend.
+ALLOWED_URL_SCHEMES = ('http', 'https')
+
 VALIDATION_MESSAGES = {
     'WHEEL_ID_REQUIRED': "wheel_id is required",
     'PARTICIPANT_ID_REQUIRED': "participant_id is required",
     'PARTICIPANT_NAME_REQUIRED': "participant_name is required and must be a non-empty string",
     'PARTICIPANT_NAME_TOO_LONG': f"participant_name must be {PARTICIPANT_CONSTRAINTS['MAX_NAME_LENGTH']} characters or less",
     'PARTICIPANT_URL_TOO_LONG': f"participant_url must be {PARTICIPANT_CONSTRAINTS['MAX_URL_LENGTH']} characters or less",
+    'PARTICIPANT_URL_INVALID_SCHEME': "participant_url must be an absolute http:// or https:// URL",
     'INVALID_WEIGHT': f"weight must be a number between {PARTICIPANT_CONSTRAINTS['MIN_WEIGHT']} and {PARTICIPANT_CONSTRAINTS['MAX_WEIGHT']}",
     'INVALID_REQUEST_BODY': "Invalid request body format",
     'PARTICIPANT_EXISTS': "Participant '{}' already exists in this wheel",
@@ -108,9 +115,23 @@ def validate_participant_name(participant_name: str) -> None:
 
 
 def validate_participant_url(participant_url: str) -> None:
-    """Validate participant URL"""
-    if participant_url and len(participant_url) > PARTICIPANT_CONSTRAINTS['MAX_URL_LENGTH']:
+    """Validate participant URL: optional, length-bounded, and http/https scheme only.
+
+    An empty/omitted URL is allowed (the field is optional). When a value is
+    provided it must be an absolute http:// or https:// URL; any other scheme
+    (javascript:, data:, vbscript:, file:, mailto:, relative, etc.) is rejected
+    to prevent stored XSS at the frontend window.open()/<a href> sinks.
+    """
+    if not participant_url:
+        return
+    if len(participant_url) > PARTICIPANT_CONSTRAINTS['MAX_URL_LENGTH']:
         raise BadRequestError(VALIDATION_MESSAGES['PARTICIPANT_URL_TOO_LONG'])
+    try:
+        scheme = urlparse(participant_url).scheme.lower()
+    except ValueError:
+        raise BadRequestError(VALIDATION_MESSAGES['PARTICIPANT_URL_INVALID_SCHEME'])
+    if scheme not in ALLOWED_URL_SCHEMES:
+        raise BadRequestError(VALIDATION_MESSAGES['PARTICIPANT_URL_INVALID_SCHEME'])
 
 
 def validate_weight(weight: Any) -> float:

--- a/api-v2/tests/test_participant_url_xss.py
+++ b/api-v2/tests/test_participant_url_xss.py
@@ -1,0 +1,92 @@
+#  Bug Condition Exploration Tests - Participant URL Stored XSS
+#  Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  These tests encode the EXPECTED (fixed) behavior for the participant_url
+#  stored XSS vulnerability. They are expected to FAIL on unfixed code (where
+#  validate_participant_url checks only length), proving the bug exists, and to
+#  PASS once the http/https scheme allowlist is enforced.
+#
+#  Bug: A Wheel Admin can store a participant_url with a dangerous scheme
+#  (e.g. "javascript:...") because server-side validation checked only length,
+#  not scheme. The stored URL is later passed to window.open()/<a href> in the
+#  frontend, so the script executes in a victim admin's session and can read the
+#  Cognito idToken from localStorage -> account takeover.
+#
+#  Sink (frontend): ui-v2/src/components/wheel.jsx window.open(participant_url)
+#  Control (server): api-v2/participant_operations.py validate_participant_url
+
+import os
+import sys
+import pytest
+
+# Add the parent directory to the Python path so we can import api-v2 modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from base import BadRequestError
+from participant_operations import validate_participant_url, ALLOWED_URL_SCHEMES
+
+
+# -- Payloads --------------------------------------------------------------
+
+# Representative payload for the stored XSS, plus sibling dangerous schemes.
+DANGEROUS_URLS = [
+    "javascript:var W=window.opener||window;"
+    "W.document.title='TOKEN STOLEN';",
+    "javascript:alert(document.domain)",
+    "JavaScript:alert(1)",                     # scheme is case-insensitive
+    "  javascript:alert(1)",                   # leading whitespace
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "file:///etc/passwd",
+    "mailto:attacker@example.com",
+    "ftp://example.com/x",
+    "//evil.example.com",                      # scheme-relative, no scheme
+    "/relative/path",                          # relative, no scheme
+    "not-a-url",
+]
+
+SAFE_URLS = [
+    "https://example.com/participant",
+    "http://example.com",
+    "https://sub.example.com/path?q=1#frag",
+    "HTTPS://EXAMPLE.COM",                      # uppercase http(s) still allowed
+]
+
+
+# -- Server-side scheme allowlist ------------------------------------------
+
+@pytest.mark.parametrize("url", DANGEROUS_URLS)
+def test_validate_participant_url_rejects_dangerous_scheme(url):
+    """SECURITY: validate_participant_url must reject any non-http(s) scheme.
+
+    On unfixed code (length-only check) these all pass validation, which is the
+    bug. The fix raises BadRequestError for every dangerous scheme.
+    """
+    with pytest.raises(BadRequestError):
+        validate_participant_url(url)
+
+
+@pytest.mark.parametrize("url", SAFE_URLS)
+def test_validate_participant_url_accepts_http_and_https(url):
+    """Legitimate absolute http/https URLs must continue to validate."""
+    # Should not raise.
+    validate_participant_url(url)
+
+
+@pytest.mark.parametrize("empty", ["", None])
+def test_validate_participant_url_allows_empty(empty):
+    """participant_url is optional; empty/None must remain allowed."""
+    # Should not raise.
+    validate_participant_url(empty)
+
+
+def test_validate_participant_url_still_enforces_length():
+    """The pre-existing length bound must remain enforced for http/https URLs."""
+    too_long = "https://example.com/" + ("a" * 600)
+    with pytest.raises(BadRequestError):
+        validate_participant_url(too_long)
+
+
+def test_allowed_schemes_are_only_http_https():
+    """Guard against accidental widening of the scheme allowlist."""
+    assert set(ALLOWED_URL_SCHEMES) == {"http", "https"}

--- a/ui-v2/src/auth_storage.jsx
+++ b/ui-v2/src/auth_storage.jsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * In-memory token store for Cognito auth (stored-XSS hardening follow-up).
+ *
+ * WHY: Cognito id/access/refresh tokens previously lived in localStorage, which
+ * is readable by any script in the origin. Combined with an XSS sink that was a
+ * credential-theft -> account-takeover chain. Keeping the tokens in a JS closure
+ * (this module's `store`) instead of localStorage removes the exfiltration
+ * surface: there is nothing for `localStorage.getItem('idToken')` (or a scan of
+ * `CognitoIdentityServiceProvider.*` keys) to read.
+ *
+ * TRADE-OFF: in-memory storage does not survive a full page reload or a new tab,
+ * so the user re-authenticates after a hard refresh. This is intentional. The
+ * only way to keep cross-reload persistence while remaining unreadable by JS is
+ * HttpOnly cookies, which requires backend/API-Gateway-authorizer changes and is
+ * out of scope for this frontend change.
+ *
+ * This class implements the subset of the Web Storage API that
+ * amazon-cognito-identity-js requires, so it can be passed as the `Storage`
+ * option to CognitoUserPool / CognitoUser.
+ */
+class InMemoryStorage {
+  constructor() {
+    this.store = {};
+  }
+
+  setItem(key, value) {
+    this.store[key] = String(value);
+  }
+
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;
+  }
+
+  removeItem(key) {
+    delete this.store[key];
+  }
+
+  clear() {
+    this.store = {};
+  }
+
+  get length() {
+    return Object.keys(this.store).length;
+  }
+
+  key(index) {
+    const keys = Object.keys(this.store);
+    return index >= 0 && index < keys.length ? keys[index] : null;
+  }
+
+  /** Return the first stored key matching the predicate, or null. */
+  findKey(predicate) {
+    return Object.keys(this.store).find(predicate) || null;
+  }
+}
+
+// Single shared instance: the pool, every CognitoUser, and all token readers
+// must see the same store.
+export const authStorage = new InMemoryStorage();
+
+/**
+ * Read the current Cognito ID token (JWT) from the in-memory store.
+ * amazon-cognito-identity-js persists it under a
+ * `CognitoIdentityServiceProvider.<clientId>.<user>.idToken` key; older code
+ * also wrote a plain `idToken` key, which we still honour for compatibility.
+ *
+ * @returns {string|null} the raw JWT, or null if not authenticated.
+ */
+export const getStoredIdToken = () => {
+  const direct = authStorage.getItem('idToken');
+  if (direct) {
+    return direct;
+  }
+  const key = authStorage.findKey(k =>
+    k.includes('CognitoIdentityServiceProvider') && k.endsWith('.idToken'));
+  return key ? authStorage.getItem(key) : null;
+};
+
+/** Clear all auth tokens (used on logout / auth failure). */
+export const clearStoredTokens = () => {
+  authStorage.clear();
+};

--- a/ui-v2/src/components/PermissionContext.jsx
+++ b/ui-v2/src/components/PermissionContext.jsx
@@ -15,6 +15,7 @@
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { authenticatedFetch, apiURL } from '../util';
+import { getStoredIdToken, clearStoredTokens } from '../auth_storage';
 
 // Permission mappings matching backend role definitions
 const ROLE_PERMISSIONS = {
@@ -108,7 +109,7 @@ export const PermissionProvider = ({ children, validateWithBackend = false }) =>
         tokenInfo = extractUserInfoFromToken();
       } catch (error) {
         console.warn('Failed to extract user info from token:', error);
-        localStorage.removeItem('idToken');
+        clearStoredTokens();
         window.location.href = '/app/login';
         return;
       }
@@ -138,7 +139,7 @@ export const PermissionProvider = ({ children, validateWithBackend = false }) =>
               permissions: backendUserInfo.permissions || {}
             };
           } else if (response && response.status === 401) {
-            localStorage.removeItem('idToken');
+            clearStoredTokens();
             window.location.href = '/app/login';
             return;
           } else {
@@ -179,17 +180,8 @@ export const PermissionProvider = ({ children, validateWithBackend = false }) =>
   };
 
   const extractUserInfoFromToken = () => {
-    let idToken = localStorage.getItem('idToken');
-    
-    if (!idToken) {
-      const cognitoKeys = Object.keys(localStorage).filter(key => 
-        key.includes('CognitoIdentityServiceProvider') && key.endsWith('.idToken')
-      );
-      
-      if (cognitoKeys.length > 0) {
-        idToken = localStorage.getItem(cognitoKeys[0]);
-      }
-    }
+    // Read the ID token from the in-memory auth store (never localStorage).
+    let idToken = getStoredIdToken();
 
     if (!idToken) {
       return null;
@@ -200,7 +192,7 @@ export const PermissionProvider = ({ children, validateWithBackend = false }) =>
       
       const currentTime = Math.floor(Date.now() / 1000);
       if (payload.exp && payload.exp < currentTime) {
-        localStorage.removeItem('idToken');
+        clearStoredTokens();
         return null;
       }
 

--- a/ui-v2/src/components/app.jsx
+++ b/ui-v2/src/components/app.jsx
@@ -28,6 +28,7 @@ import '../styles.css';
 import {CognitoUserPool} from 'amazon-cognito-identity-js';
 import {BrowserRouter} from 'react-router-dom';
 import {setAPIConfig} from '../util';
+import {authStorage, clearStoredTokens} from '../auth_storage';
 import { PermissionProvider, usePermissions } from './PermissionContext';
 
 // Lazy load heavy components for better performance
@@ -42,12 +43,6 @@ const INITIAL_STATE = {
   cognitoUserPool: undefined,
   cognitoSession: undefined,
   showTenantCreation: false
-};
-
-const TOKEN_KEYS = {
-  ID_TOKEN: 'idToken',
-  ACCESS_TOKEN: 'accessToken',
-  REFRESH_TOKEN: 'refreshToken'
 };
 
 const ROUTES = {
@@ -86,6 +81,7 @@ class App extends Component {
       const cognitoUserPool = new CognitoUserPool({
         UserPoolId: this.props.configFetch.value.UserPoolId,
         ClientId: this.props.configFetch.value.ClientId,
+        Storage: authStorage,
       })
       this.setState({cognitoUserPool}, this.refreshSession);
     }
@@ -100,22 +96,17 @@ class App extends Component {
           return;
         }
         const idToken = session.getIdToken().getJwtToken();
-        
+
         // Only update state if the session actually changed to prevent unnecessary re-renders
         const currentIdToken = app.state.cognitoSession?.getIdToken()?.getJwtToken();
-        const currentStoredToken = localStorage.getItem(TOKEN_KEYS.ID_TOKEN);
-        
+
         if (currentIdToken !== idToken) {
-          // Store token for both react-redux-fetch and direct API calls
+          // Register the token as an in-memory request header for react-redux-fetch.
+          // The Cognito session tokens themselves live only in the in-memory
+          // authStorage (see auth_storage.jsx); we deliberately no longer copy them
+          // into localStorage, so a stored-XSS payload cannot read them.
           container.registerRequestHeader('Authorization', idToken);
-          
-          // Only update localStorage if the token is actually different to prevent storage events
-          if (currentStoredToken !== idToken) {
-            localStorage.setItem(TOKEN_KEYS.ID_TOKEN, idToken);
-            localStorage.setItem(TOKEN_KEYS.ACCESS_TOKEN, session.getAccessToken().getJwtToken());
-            localStorage.setItem(TOKEN_KEYS.REFRESH_TOKEN, session.getRefreshToken().getToken());
-          }
-          
+
           app.setState({cognitoSession: session});
         }
       })
@@ -124,10 +115,9 @@ class App extends Component {
 
   userLogout = () => {
     this.state.cognitoUserPool.getCurrentUser().signOut();
-    // Clear stored tokens
-    localStorage.removeItem(TOKEN_KEYS.ID_TOKEN);
-    localStorage.removeItem(TOKEN_KEYS.ACCESS_TOKEN);
-    localStorage.removeItem(TOKEN_KEYS.REFRESH_TOKEN);
+    // Clear in-memory tokens (see auth_storage.jsx). signOut() already clears the
+    // Cognito keys from authStorage; this also drops any legacy plain keys.
+    clearStoredTokens();
     this.setState(INITIAL_STATE);
   }
 
@@ -135,6 +125,7 @@ class App extends Component {
     return new CognitoUserPool({
       UserPoolId: config.UserPoolId,
       ClientId: config.ClientId,
+      Storage: authStorage,
     });
   }
 

--- a/ui-v2/src/components/forgot_password.jsx
+++ b/ui-v2/src/components/forgot_password.jsx
@@ -18,6 +18,7 @@ import PropTypes from "prop-types";
 import { Alert, Button, Form } from "react-bootstrap";
 import { CognitoUser } from "amazon-cognito-identity-js";
 import { withRouter } from 'react-router-dom';
+import {authStorage} from '../auth_storage';
 
 // Forgot Password Component Constants
 const FORGOT_PASSWORD_CONFIG = {
@@ -110,7 +111,8 @@ class ForgotPassword extends Component {
     
     const cognitoUser = new CognitoUser({
       Username: this.state.username,
-      Pool: this.props.userPool
+      Pool: this.props.userPool,
+      Storage: authStorage
     });
 
     // Use forgotPassword directly - Cognito will handle email lookup internally

--- a/ui-v2/src/components/login.jsx
+++ b/ui-v2/src/components/login.jsx
@@ -18,6 +18,7 @@ import PropTypes from "prop-types";
 import {Alert, Button, Form} from "react-bootstrap";
 import {AuthenticationDetails, CognitoUser} from "amazon-cognito-identity-js";
 import { withRouter } from 'react-router-dom';
+import {authStorage} from '../auth_storage';
 
 // Login Component Constants
 const LOGIN_CONFIG = {
@@ -121,7 +122,7 @@ class Login extends Component {
   login = (event) => {
     event.preventDefault();
     this.setState({isInFlight: true});
-    const user = new CognitoUser({ Username: this.state.username, Pool: this.props.userPool });
+    const user = new CognitoUser({ Username: this.state.username, Pool: this.props.userPool, Storage: authStorage });
     const authenticationData = { Username: this.state.username, Password: this.state.password };
     const authenticationDetails = new AuthenticationDetails(authenticationData);
     this.setState({user}, () => user.authenticateUser(authenticationDetails, this));

--- a/ui-v2/src/components/reset_password.jsx
+++ b/ui-v2/src/components/reset_password.jsx
@@ -18,6 +18,7 @@ import PropTypes from "prop-types";
 import { Alert, Button, Form } from "react-bootstrap";
 import { CognitoUser } from "amazon-cognito-identity-js";
 import { withRouter } from 'react-router-dom';
+import {authStorage} from '../auth_storage';
 
 // Reset Password Component Constants
 const RESET_PASSWORD_CONFIG = {
@@ -165,7 +166,8 @@ class ResetPassword extends Component {
     
     const cognitoUser = new CognitoUser({
       Username: this.state.username,
-      Pool: this.props.userPool
+      Pool: this.props.userPool,
+      Storage: authStorage
     });
 
     cognitoUser.confirmPassword(this.state.code, this.state.password, {

--- a/ui-v2/src/components/user_table/user_table.jsx
+++ b/ui-v2/src/components/user_table/user_table.jsx
@@ -21,6 +21,7 @@ import UserModal from './user_modal';
 import DeleteWheelGroupModal from './delete_wheel_group_modal';
 import {Card, Table, Button, Modal, Alert, Form, InputGroup} from 'react-bootstrap';
 import {apiURL, getAuthHeaders} from '../../util';
+import {clearStoredTokens} from '../../auth_storage';
 import PermissionGuard, { usePermissions } from '../PermissionGuard';
 
 // Constants
@@ -148,7 +149,10 @@ export class UserTable extends Component {
 
   performCompleteLogout = () => {
     try {
-      // Clear all possible authentication tokens
+      // Clear in-memory auth tokens (the source of truth; see auth_storage.jsx).
+      clearStoredTokens();
+
+      // Clear any legacy authentication tokens that may linger in web storage.
       localStorage.removeItem('userToken');
       localStorage.removeItem('idToken');
       localStorage.removeItem('accessToken');

--- a/ui-v2/src/components/wheel.jsx
+++ b/ui-v2/src/components/wheel.jsx
@@ -19,7 +19,7 @@ import ReactDOM from 'react-dom';
 import connect from 'react-redux-fetch';
 import {Button} from 'react-bootstrap';
 import {WheelType, ParticipantType} from '../types';
-import {LinkWrapper, WHEEL_COLORS, apiURL, staticURL, getAuthHeaders} from '../util';
+import {LinkWrapper, WHEEL_COLORS, apiURL, staticURL, getAuthHeaders, isSafeHttpUrl} from '../util';
 import {usePermissions} from './PermissionContext';
 import '../static_content/wheel_click.mp3';
 import 'isomorphic-fetch';
@@ -513,8 +513,16 @@ export class Wheel extends PureComponent {
     // POST the selected participant (this also un-rigs the wheel)
     this.props.dispatchParticipantSelectPost(this.props.match.params.wheel_id, this.state.selectedParticipant.participant_id);
 
-    // Open the participant's URL
-    window.open(this.state.selectedParticipant.participant_url);
+    // Open the participant's URL. Only http/https URLs are opened; a stored
+    // javascript:/data:/etc. participant_url is refused here as defense-in-depth
+    // (the server-side scheme allowlist is the primary control). noopener,noreferrer
+    // severs window.opener so the opened page cannot reach back into this app.
+    const participantUrl = this.state.selectedParticipant.participant_url;
+    if (isSafeHttpUrl(participantUrl)) {
+      window.open(participantUrl, '_blank', 'noopener,noreferrer');
+    } else if (participantUrl) {
+      console.warn('Refusing to open participant_url with disallowed scheme:', participantUrl);
+    }
   }
 
   toggleSound = () => {

--- a/ui-v2/src/util.jsx
+++ b/ui-v2/src/util.jsx
@@ -17,8 +17,27 @@ import React, {Component} from 'react';
 import moment from 'moment';
 import * as moment_tz from 'moment-timezone';
 import {Link} from 'react-router-dom';
+import {getStoredIdToken, clearStoredTokens} from './auth_storage';
 
 export const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+
+// Only absolute http/https URLs are safe to hand to window.open() or an <a href>.
+// Everything else (javascript:, data:, vbscript:, file:, relative, malformed)
+// is rejected to prevent stored XSS from a participant_url. This mirrors the
+// server-side scheme allowlist in api-v2/participant_operations.py and is
+// defense-in-depth: the frontend must never trust a stored URL is safe.
+export function isSafeHttpUrl(url) {
+  if (typeof url !== 'string' || url.length === 0) {
+    return false;
+  }
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch (e) {
+    return false;
+  }
+  return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+}
 export function formatDateTime(timestamp, withTimeZone) {
     if (withTimeZone) {
         const dateTimeFormat = 'YYYY-MM-DD HH:mm:ss z';
@@ -78,21 +97,10 @@ export const staticURL = (urlSuffix) => {
 
 // Authentication utilities for JWT tokens
 export const getAuthHeaders = () => {
-  // First try the simple key (for compatibility)
-  let idToken = localStorage.getItem('idToken');
-  
-  // If not found, look for Cognito-stored ID token
-  if (!idToken) {
-    // Find Cognito ID token in localStorage
-    const cognitoKeys = Object.keys(localStorage).filter(key => 
-      key.includes('CognitoIdentityServiceProvider') && key.endsWith('.idToken')
-    );
-    
-    if (cognitoKeys.length > 0) {
-      idToken = localStorage.getItem(cognitoKeys[0]);
-    }
-  }
-  
+  // Read the ID token from the in-memory auth store (never localStorage) so a
+  // stored-XSS payload cannot read it. See auth_storage.jsx.
+  const idToken = getStoredIdToken();
+
   if (idToken) {
     return {
       'Authorization': `Bearer ${idToken}`,
@@ -121,10 +129,8 @@ export const authenticatedFetch = async (url, options = {}) => {
     
     // Handle authentication errors
     if (response.status === 401 || response.status === 403) {
-      // Clear stored tokens and redirect to login
-      localStorage.removeItem('idToken');
-      localStorage.removeItem('accessToken');
-      localStorage.removeItem('refreshToken');
+      // Clear in-memory tokens and redirect to login. See auth_storage.jsx.
+      clearStoredTokens();
       window.location.href = '/app/login';
       return;
     }
@@ -138,7 +144,7 @@ export const authenticatedFetch = async (url, options = {}) => {
 
 // Wheel Group context utilities
 export const getTenantContext = () => {
-  const idToken = localStorage.getItem('idToken');
+  const idToken = getStoredIdToken();
   if (idToken) {
     try {
       // Decode JWT payload (this is safe for reading, not for validation)
@@ -179,9 +185,17 @@ export class LinkWrapper extends Component {
     else {
       /* istanbul ignore next */
       if (isRemote) {
-        // For external URLs, use regular anchor tag
+        // For external URLs, use regular anchor tag. Only render an href for
+        // safe http/https URLs; anything else (javascript:, data:, ...) is
+        // rendered as inert text so a stored malicious participant_url cannot
+        // execute when clicked. rel prevents reverse-tabnabbing via window.opener.
         const {to, ...anchorProps} = props;
-        link = <a href={to} {...anchorProps}>{props.children}</a>;
+        if (isSafeHttpUrl(to)) {
+          link = <a href={to} rel='noopener noreferrer' {...anchorProps}>{props.children}</a>;
+        } else {
+          const {target, ...safeProps} = anchorProps;
+          link = <span {...safeProps}>{props.children}</span>;
+        }
       } else {
         // For internal routes, use React Router Link
         link = <Link {...props}>{props.children}</Link>;

--- a/ui-v2/test/auth_storage.test.jsx
+++ b/ui-v2/test/auth_storage.test.jsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *   http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * Tests for the in-memory Cognito token store (stored-XSS hardening follow-up).
+ *
+ * The security goal: auth tokens must live only in this in-memory store, never
+ * in localStorage, so a stored-XSS payload cannot exfiltrate them. These tests
+ * assert the store behaves like the Web Storage subset amazon-cognito-identity-js
+ * needs, that getStoredIdToken resolves both key styles, and -- critically --
+ * that writing tokens through it never touches window.localStorage.
+ */
+
+import {expect} from 'chai';
+import {authStorage, getStoredIdToken, clearStoredTokens} from '../src/auth_storage';
+
+describe('auth_storage (in-memory token store)', function() {
+
+  afterEach(() => {
+    clearStoredTokens();
+  });
+
+  it('implements the Web Storage subset used by amazon-cognito-identity-js', () => {
+    expect(authStorage.getItem('missing')).to.equal(null);
+    authStorage.setItem('a', 'x');
+    authStorage.setItem('b', 'y');
+    expect(authStorage.getItem('a')).to.equal('x');
+    expect(authStorage.length).to.equal(2);
+    expect(authStorage.key(0)).to.equal('a');
+    authStorage.removeItem('a');
+    expect(authStorage.getItem('a')).to.equal(null);
+    expect(authStorage.length).to.equal(1);
+    authStorage.clear();
+    expect(authStorage.length).to.equal(0);
+    expect(authStorage.key(0)).to.equal(null);
+  });
+
+  it('coerces stored values to strings, like real Storage', () => {
+    authStorage.setItem('n', 123);
+    expect(authStorage.getItem('n')).to.equal('123');
+  });
+
+  it('getStoredIdToken returns the plain idToken key when present', () => {
+    authStorage.setItem('idToken', 'JWT_PLAIN');
+    expect(getStoredIdToken()).to.equal('JWT_PLAIN');
+  });
+
+  it('getStoredIdToken falls back to the CognitoIdentityServiceProvider key', () => {
+    authStorage.setItem(
+      'CognitoIdentityServiceProvider.abc123.alice.idToken', 'JWT_COGNITO');
+    expect(getStoredIdToken()).to.equal('JWT_COGNITO');
+  });
+
+  it('getStoredIdToken returns null when no token is stored', () => {
+    expect(getStoredIdToken()).to.equal(null);
+  });
+
+  it('clearStoredTokens empties the store', () => {
+    authStorage.setItem('idToken', 'JWT');
+    authStorage.setItem('CognitoIdentityServiceProvider.abc.bob.accessToken', 'A');
+    clearStoredTokens();
+    expect(getStoredIdToken()).to.equal(null);
+    expect(authStorage.length).to.equal(0);
+  });
+
+  it('SECURITY: storing tokens must never write to window.localStorage', () => {
+    // The whole point of the migration: an XSS payload reading localStorage must
+    // find nothing. Simulate the pool/user writing session tokens through the
+    // store and assert localStorage stays empty.
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.clear();
+    }
+    authStorage.setItem('idToken', 'JWT');
+    authStorage.setItem('CognitoIdentityServiceProvider.abc.carol.idToken', 'JWT2');
+    authStorage.setItem('CognitoIdentityServiceProvider.abc.carol.refreshToken', 'RT');
+
+    if (typeof window !== 'undefined' && window.localStorage) {
+      expect(window.localStorage.getItem('idToken')).to.equal(null);
+      const leaked = Object.keys(window.localStorage).filter(k =>
+        k.includes('CognitoIdentityServiceProvider') || k === 'idToken');
+      expect(leaked).to.have.lengthOf(0);
+    }
+    // The token is still retrievable from the in-memory store for the app's use.
+    expect(getStoredIdToken()).to.equal('JWT');
+  });
+});

--- a/ui-v2/test/components/wheel.test.jsx
+++ b/ui-v2/test/components/wheel.test.jsx
@@ -285,10 +285,31 @@ describe('Wheel', function() {
     };
     const wrapper = shallowWithStore(<Wheel {...Object.assign({}, props, shallowProps, dispatchProps, testProps)} />);
     window.open = sinon.spy();
-    wrapper.instance().setState({selectedParticipant: {wheel_id: 'test_wheel_id', id: 'test_id', url: 'test_url'}});
+    wrapper.instance().setState({selectedParticipant: {wheel_id: 'test_wheel_id', participant_id: 'test_id', participant_url: 'https://example.com/prize'}});
     wrapper.instance().openParticipantPage();
     expect(dispatchProps.dispatchParticipantSelectPost.calledWith('test_wheel_id', 'test_id')).to.be.true;
-    expect(window.open.calledWith('test_url')).to.be.true;
+    expect(window.open.calledWith('https://example.com/prize', '_blank', 'noopener,noreferrer')).to.be.true;
+  });
+
+  it('SECURITY: Should refuse to window.open a participant_url with a dangerous scheme', () => {
+    // Encodes fixed behavior for the participant_url stored XSS: a
+    // javascript:/data:/etc. participant_url must never reach window.open().
+    const testProps = {
+      participantSuggestFetch: {
+        fulfilled: false,
+        rejected: true,
+        pending: false,
+        value: participants,
+      },
+    };
+    const wrapper = shallowWithStore(<Wheel {...Object.assign({}, props, shallowProps, dispatchProps, testProps)} />);
+    window.open = sinon.spy();
+    wrapper.instance().setState({selectedParticipant: {wheel_id: 'test_wheel_id', participant_id: 'test_id',
+      participant_url: "javascript:alert(document.domain)"}});
+    wrapper.instance().openParticipantPage();
+    // Selection is still recorded, but the malicious URL is never opened.
+    expect(dispatchProps.dispatchParticipantSelectPost.calledWith('test_wheel_id', 'test_id')).to.be.true;
+    expect(window.open.called).to.be.false;
   });
 
   it('Should not do anything on openParticipantPage if the wheel is still spinning', () => {


### PR DESCRIPTION
A Wheel Admin could store a participant_url with a dangerous scheme (e.g. javascript:) because server-side validation checked only length. The stored URL was later passed unsanitized to window.open() and an </a href>/ sink in the frontend, so the script executed in a victim admin's session and could read the Cognito idToken from localStorage, leading to account takeover within a self-deployed instance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
